### PR TITLE
Integration weights

### DIFF
--- a/SFS_general/rounded_box.m
+++ b/SFS_general/rounded_box.m
@@ -142,10 +142,12 @@ n0(:,1:2) = [sum( n0 .* rotx(rot_ind, :), 2), sum( n0 .* roty(rot_ind, :), 2)];
 
 %% ===== Weights =============================================================
 
-% distance between adjacent samples
+% Distance between adjacent samples. This takes the special geometry into
+% account and is faster than using the more general secondary_source_distance()
+% function.
 dist = mod( t - t([N,1:N-1]), 1);  % distance to neighbor
 dist = min( abs(dist), abs(1 - dist) );  % take periodicity into account
-% half of the distance to the "left" and half of the distance to the
+% Half of the distance to the "left" and half of the distance to the
 % "right" neighbor
 w0 = ( 0.5*dist + 0.5*dist([2:N,1]) )*4*l;
 w0 = w0.';

--- a/SFS_general/rounded_box.m
+++ b/SFS_general/rounded_box.m
@@ -1,8 +1,8 @@
-function [x0, n0] = rounded_box(t, ratio)
+function [x0, n0, w0] = rounded_box(t, ratio)
 %ROUNDED_BOX computes position and direction vectors in 3D given a parameter 
 %   indicating the position on the boundary of a box with rounded corners.
 %
-%   Usage: [x0, n0] = rounded_box(t, ratio)
+%   Usage: [x0, n0, w0] = rounded_box(t, ratio)
 %
 %   Input options:
 %       t      - parameter indicating position on the boundary [1 x n]
@@ -12,19 +12,28 @@ function [x0, n0] = rounded_box(t, ratio)
 %   Output options:
 %       x0     - positions [n x 3]
 %       n0     - unit vector for boundaries normal vector [n x 3]
+%       w0     - weights for integration [n x 1]
 %
 %   The box has rectangular bounding box in the horizontal plane with an edge 
 %   length of 2 and its center at [0,0,0]. Choosing 0.0 for ratio leads to a
-%   square, while 1.0 yields a circle. 
+%   square, while 1.0 yields a circle.
+%
 %   The parameter t indicates the position on the boundary starting for t=0 
 %   yielding x0=[1,0,0] and following the boundary in a counter-clockwise
 %   manner. This function is periodic with respect to t with a period of 1.
 %   Given two parameters t1 and t2=t1+delta, this function yields two positions
 %   x01=rounded_box(t1, ratio) and x02=rounded_box(t2, ratio), whose distance 
 %   ALONG THE BOUNDARY of the box is rounded_box(delta, ratio).
-%   n0 is orthogonal to the boundary and poiting inwards the box. 
-%   However, for ratio=1 and t=1/8, 3/8, 5/8, ..., i.e a location in a corner
-%   of a square, n0 has an angle of 45 degree to the adjacent edges of the box.
+%
+%   n0 is orthogonal to the boundary and is pointing inwards the box. However, 
+%   for ratio=1 and t=1/8, 3/8, 5/8, ..., i.e a location in a corner of a
+%   square, n0 has an angle of 45 degree to the adjacent edges of the box.
+%
+%   For a correct computation of the integration weights the elements have
+%   to be sorted, either in ascending or descending order. It is further 
+%   assumed, that the last element of t is the "left" neighbor of the first
+%   element. The weights are computed on the distance of neighboring elements
+%   ALONG THE BOUNDARY of the box.
 %
 % See also: secondary_source_positions
 
@@ -71,14 +80,16 @@ if ratio > 1.0
   error('%s: ratio has to be between 0.0 and 1.0', upper(mfilename));
 end
 
-%% ===== Computation =========================================================
+%% ===== Variables ===========================================================
+
+N = length(t);
 
 ratio_prime = (1.0 - ratio);
 
 % the rounded box can be divided into four quarters, where each can be handled
 % in the same manner and is rotated afterwards
 rot_ind = mod( floor(t*4), 4 ) + 1;  % index for rotating
-t = mod(t, 0.25)*4;  % map t to a single quarter
+tseg = mod(t, 0.25)*4;  % map t to a single quarter
 
 % length of a quarter of the rounded box
 % (quarter circle + 2*linear segment);
@@ -87,21 +98,23 @@ l = pi/2*ratio + 2*ratio_prime;
 circle = ratio_prime./l;  % value of t, where circular segment begins
 circle_prime = 1.0 - circle;  % value t, where circular segment ends
 
-x0 = zeros(length(t), 3);
-n0 = zeros(length(t), 3);
+%% ===== Positions & Orientations ============================================
+
+x0 = zeros(N, 3);
+n0 = zeros(N, 3);
 
 %%%%% first linear segment %%%%%
-seglin1 = ( t < circle );
+seglin1 = ( tseg < circle );
 % x0 = [1.0, t*l, 0]
 x0(seglin1, 1) = 1.0;
-x0(seglin1, 2) = t(seglin1)*l;
+x0(seglin1, 2) = tseg(seglin1)*l;
 % n0 = [-1.0, 0, 0]
 n0(seglin1, 1) = -1.0;
 
 %%%%% second linear segment %%%%%
-seglin2 = ( t > circle_prime );
+seglin2 = ( tseg > circle_prime );
 % x0 = [(1.0-t)*l, 1.0, 0]
-x0(seglin2 , 1) = ( 1.0 - t(seglin2) ) * l;
+x0(seglin2 , 1) = ( 1.0 - tseg(seglin2) ) * l;
 x0(seglin2 , 2) = 1.0;
 % n0 = [0, -1.0, 0]
 n0(seglin2, 2) = -1.0;
@@ -111,7 +124,7 @@ segcirc = ~( seglin1 | seglin2 );
 if ratio == 0
   phi = pi/4;
 else
-  phi = (t(segcirc) - circle)./(circle_prime - circle)*pi/2;
+  phi = (tseg(segcirc) - circle)./(circle_prime - circle)*pi/2;
 end
 % x0 = circle_center + ratio*[cos(phi), sin(phi), 0]
 x0(segcirc, 1) = ratio_prime + ratio*cos(phi);
@@ -126,5 +139,15 @@ roty = [0, 1, 0; 1, 0, 0; 0,-1, 0;-1, 0, 0];
 
 x0(:,1:2) = [sum( x0 .* rotx(rot_ind, :), 2), sum( x0 .* roty(rot_ind, :), 2)];
 n0(:,1:2) = [sum( n0 .* rotx(rot_ind, :), 2), sum( n0 .* roty(rot_ind, :), 2)];
+
+%% ===== Weights =============================================================
+
+% distance between adjacent samples
+dist = mod( t - t([N,1:N-1]), 1);  % distance to neighbor
+dist = min( abs(dist), abs(1 - dist) );  % take periodicity into account
+% half of the distance to the "left" and half of the distance to the
+% "right" neighbor
+w0 = ( 0.5*dist + 0.5*dist([2:N,1]) )*4*l;
+w0 = w0.';
 
 end

--- a/SFS_general/secondary_source_positions.m
+++ b/SFS_general/secondary_source_positions.m
@@ -113,7 +113,7 @@ if strcmp('line',geometry) || strcmp('linear',geometry)
     x0(:,3) = X0(3) * ones(nls,1);
     % Direction of the secondary sources pointing to the -y direction
     x0(:,4:6) = direction_vector(x0(:,1:3),x0(:,1:3)+repmat([0 -1 0],nls,1));
-    % weight each distance with its distance to its neighbors
+    % Weight each secondary source by the inter-loudspeaker distance
     x0(:,7) = L./(nls-1);
 elseif strcmp('circle',geometry) || strcmp('circular',geometry)
     % === Circular array ===
@@ -140,10 +140,10 @@ elseif strcmp('circle',geometry) || strcmp('circular',geometry)
     %
     % 'circle' is special case of 'rounded-box' with fully rounded corners
     t = (0:nls-1)/nls;
-    [x0(:,1:3), x0(:,4:6), x0(:,7)] = rounded_box(t, 1.0);  % 1.0 for circle
-    % scale unit circle
-    x0(:,1:3) = bsxfun(@plus, x0(:,1:3).*L/2, X0);  
-    % scale weights
+    [x0(:,1:3), x0(:,4:6), x0(:,7)] = rounded_box(t,1.0);  % 1.0 for circle
+    % Scale unit circle and shift center to X0
+    x0(:,1:3) = bsxfun(@plus, x0(:,1:3).*L/2, X0);
+    % Scale weights
     x0(:,7) = x0(:,7).*L/2;
 elseif strcmp('box',geometry)
     % === Boxed loudspeaker array ===
@@ -172,7 +172,7 @@ elseif strcmp('box',geometry)
     %
     % 'box' is special case of 'rounded-box' where there is no rounding
     % and the sources in the corners are skipped
-    
+    %
     % Number of secondary sources per linear array
     % ensures that nls/4 is always an integer.
     if rem(nls,4)~=0
@@ -183,28 +183,28 @@ elseif strcmp('box',geometry)
     end
     % Distance between secondary sources
     dx0 = L/(nbox-1);
-    % length of one edge of the rectangular bounding box
+    % Length of one edge of the rectangular bounding box
     Lbound = L + 2*dx0;
-    % index t for the positions on the boundary
+    % Index t for the positions on the boundary
     t = linspace(-L/2,L/2,nbox)./Lbound;  % this skips the corners
     t = [t, t+1, t+2, t+3]*0.25;  % repeat and shift to get all 4 edges
     % 'box' is special case of 'rounded-box' where there is no rounding
-    [x0(:,1:3), x0(:,4:6), x0(:,7)] = rounded_box(t, 0.0);  % 0.0 for square
-    % scale "unit" box
-    x0(:,1:3) = bsxfun(@plus, x0(:,1:3).*Lbound/2, X0);    
-    % scale integration weights
+    [x0(:,1:3), x0(:,4:6), x0(:,7)] = rounded_box(t,0.0);  % 0.0 for square
+    % Scale "unit" box and shift center to X0
+    x0(:,1:3) = bsxfun(@plus, x0(:,1:3).*Lbound/2, X0);
+    % Scale integration weights
     x0(:,7) = x0(:,7).*Lbound/2;
-    % correct weights of loudspeakers near corners
+    % Correct weights of loudspeakers near corners
     corners = [1,nbox,nbox+1,2*nbox,2*nbox+1,3*nbox,3*nbox+1,4*nbox];
-    x0(corners,7) = (1 + sqrt(2) ) *dx0/2;  % instead of 3/2 * dx0
+    x0(corners,7) = (1 + sqrt(2)) *dx0/2;  % instead of 3/2 * dx0
 elseif strcmp('rounded-box', geometry)
-    % ratio for rounding the edges
-    ratio = 2*conf.secondary_sources.corner_radius./L;     
-    t = (0:nls-1)/nls;    
+    % Ratio for rounding the edges
+    ratio = 2*conf.secondary_sources.corner_radius./L;
+    t = (0:nls-1)/nls;
     [x0(:,1:3), x0(:,4:6), x0(:,7)] = rounded_box(t, ratio);
-    % scale "unit" rounded-box
-    x0(:,1:3) = bsxfun(@plus, x0(:,1:3).*L/2, X0);    
-    % scale integration weights
+    % Scale "unit" rounded-box and shift center to X0
+    x0(:,1:3) = bsxfun(@plus, x0(:,1:3).*L/2, X0);
+    % Scale integration weights
     x0(:,7) = x0(:,7).*L/2;
 elseif strcmp('spherical',geometry) || strcmp('sphere',geometry)
     % Get spherical grid + weights

--- a/SFS_general/secondary_source_positions.m
+++ b/SFS_general/secondary_source_positions.m
@@ -113,8 +113,8 @@ if strcmp('line',geometry) || strcmp('linear',geometry)
     x0(:,3) = X0(3) * ones(nls,1);
     % Direction of the secondary sources pointing to the -y direction
     x0(:,4:6) = direction_vector(x0(:,1:3),x0(:,1:3)+repmat([0 -1 0],nls,1));
-    % Equal weights for all sources
-    x0(:,7) = ones(nls,1);
+    % weight each distance with its distance to its neighbors
+    x0(:,7) = L./(nls-1);
 elseif strcmp('circle',geometry) || strcmp('circular',geometry)
     % === Circular array ===
     %
@@ -140,11 +140,11 @@ elseif strcmp('circle',geometry) || strcmp('circular',geometry)
     %
     % 'circle' is special case of 'rounded-box' with fully rounded corners
     t = (0:nls-1)/nls;
-    [x0(:,1:3), x0(:,4:6)] = rounded_box(t, 1.0);  % 1.0 for circle
+    [x0(:,1:3), x0(:,4:6), x0(:,7)] = rounded_box(t, 1.0);  % 1.0 for circle
     % scale unit circle
     x0(:,1:3) = bsxfun(@plus, x0(:,1:3).*L/2, X0);  
-    % Equal weights for all sources
-    x0(:,7) = 1;
+    % scale weights
+    x0(:,7) = x0(:,7).*L/2;
 elseif strcmp('box',geometry)
     % === Boxed loudspeaker array ===
     %
@@ -189,20 +189,23 @@ elseif strcmp('box',geometry)
     t = linspace(-L/2,L/2,nbox)./Lbound;  % this skips the corners
     t = [t, t+1, t+2, t+3]*0.25;  % repeat and shift to get all 4 edges
     % 'box' is special case of 'rounded-box' where there is no rounding
-    [x0(:,1:3), x0(:,4:6)] = rounded_box(t, 0.0);  % 0.0 for square
+    [x0(:,1:3), x0(:,4:6), x0(:,7)] = rounded_box(t, 0.0);  % 0.0 for square
     % scale "unit" box
     x0(:,1:3) = bsxfun(@plus, x0(:,1:3).*Lbound/2, X0);    
-    % Equal weights for all sources
-    x0(:,7) = 1;
-elseif strcmp('rounded-box', geometry)    
+    % scale integration weights
+    x0(:,7) = x0(:,7).*Lbound/2;
+    % correct weights of loudspeakers near corners
+    corners = [1,nbox,nbox+1,2*nbox,2*nbox+1,3*nbox,3*nbox+1,4*nbox];
+    x0(corners,7) = (1 + sqrt(2) ) *dx0/2;  % instead of 3/2 * dx0
+elseif strcmp('rounded-box', geometry)
     % ratio for rounding the edges
     ratio = 2*conf.secondary_sources.corner_radius./L;     
     t = (0:nls-1)/nls;    
-    [x0(:,1:3), x0(:,4:6)] = rounded_box(t, ratio);
+    [x0(:,1:3), x0(:,4:6), x0(:,7)] = rounded_box(t, ratio);
     % scale "unit" rounded-box
     x0(:,1:3) = bsxfun(@plus, x0(:,1:3).*L/2, X0);    
-    % Equal weights for all sources
-    x0(:,7) = 1;
+    % scale integration weights
+    x0(:,7) = x0(:,7).*L/2;
 elseif strcmp('spherical',geometry) || strcmp('sphere',geometry)
     % Get spherical grid + weights
     [points,weights] = get_spherical_grid(nls,conf);
@@ -210,8 +213,8 @@ elseif strcmp('spherical',geometry) || strcmp('sphere',geometry)
     x0(:,1:3) = L/2 * points + repmat(X0,nls,1);
     % Secondary source directions
     x0(:,4:6) = direction_vector(x0(:,1:3),repmat(X0,nls,1));
-    % Secondary source weights
-    x0(:,7) = weights;
+    % Secondary source weights + distance scaling
+    x0(:,7) = weights .* L^2/4;
     % Add integration weights (because we integrate over a sphere) to the grid
     % weights
     [~,theta] = cart2sph(x0(:,1),x0(:,2),x0(:,3)); % get elevation

--- a/SFS_general/tapering_window.m
+++ b/SFS_general/tapering_window.m
@@ -121,6 +121,9 @@ end
 
 % Ensure the window will be a column vector
 win = column_vector(win);
+% normalize window to make sure that each sample is (on average) weighted
+% with 1
+win = win.*length(win)./sum(win);
 
 end
 


### PR DESCRIPTION
Add integration weights for regular secondary source geometries based on the distance between adjacent sources along the continuous boundary. Furthermore, the tapering window is normalized such that each source is weighted (on average) with 1.0 . Both modifications should prevent amplitude fluctuations between the reproduced soundfield for different primary source positions/directions.