### PR TITLE
Update dummy_irs()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ support](https://github.com/sfstoolbox/sfs/releases/tag/1.2.0).
 
 ### Table of Contents
 
-**[Installation](#installation)**
-**[Requirements](#requirements)**
-**[Usage](#usage)**
-  [Secondary Sources](#secondary-sources)
-  [Simulate Monochromatic Sound Fields](#simulate-monochromatic-sound-fields)
-  [Simulate Time Snapshots of Sound Fields](#simulate-time-snapshots-of-sound-fields)
-  [Make Binaural Simulations of Your Systems](#make-binaural-simulations-of-your-systems)
-  [Small helper functions](#small-helper-functions)
-  [Plotting with Matlab or gnuplot](#plotting-with-matlab-or-gnuplot)
+**[Installation](#installation)**  
+**[Requirements](#requirements)**  
+**[Usage](#usage)**  
+  [Secondary Sources](#secondary-sources)  
+  [Simulate Monochromatic Sound Fields](#simulate-monochromatic-sound-fields)  
+  [Simulate Time Snapshots of Sound Fields](#simulate-time-snapshots-of-sound-fields)  
+  [Make Binaural Simulations of Your Systems](#make-binaural-simulations-of-your-systems)  
+  [Small helper functions](#small-helper-functions)  
+  [Plotting with Matlab or gnuplot](#plotting-with-matlab-or-gnuplot)  
 **[Credits and License](#credits-and-license)**
 
 

--- a/SFS_general/findnearestneighbour.m
+++ b/SFS_general/findnearestneighbour.m
@@ -16,7 +16,7 @@ function [C,idx] = findnearestneighbour(A,b,number_of_neighbours)
 %   column vectors with the nearest neighbour points from the matrix A to the
 %   point b. In addition to the values, the indices are also returned.
 %
-%   See also: find, findrows
+%   See also: find, findrows, get_ir
 
 %*****************************************************************************
 % Copyright (c) 2010-2015 Quality & Usability Lab, together with             *
@@ -62,10 +62,6 @@ end
 if size(b,2)>1
     b=b';
 end
-if number_of_neighbours>size(A,2)
-    error(['%s: your number of neighbours to look for is larger than the ', ...
-        'available points.'],upper(mfilename));
-end
 
 
 %% ===== Computation =====================================================
@@ -73,5 +69,5 @@ end
 distance = vector_norm(bsxfun(@minus,A,b),1);
 % Sort the distances in order to find the n lowest once
 [~,idx] = sort(distance);
-idx = idx(1:number_of_neighbours);
+idx = idx(1:min(number_of_neighbours,length(idx)));
 C = A(:,idx);

--- a/SFS_general/findnearestneighbour.m
+++ b/SFS_general/findnearestneighbour.m
@@ -63,8 +63,8 @@ if size(b,2)>1
     b=b';
 end
 if number_of_neighbours>size(A,2)
-    error(['%s: your number of neighbours is larger than the available ', ...
-        'points.'],upper(mfilename));
+    error(['%s: your number of neighbours to look for is larger than the ', ...
+        'available points.'],upper(mfilename));
 end
 
 

--- a/SFS_ir/dummy_irs.m
+++ b/SFS_ir/dummy_irs.m
@@ -5,15 +5,17 @@ function sofa = dummy_irs(nsamples,conf)
 %
 %   Input parameters:
 %       nsamples  - length of impulse response in samples, default: 1024
+%       conf      - optional configuration struct (see SFS_config)
 %
 %   Output parameters:
 %       sofa      - sofa struct
 %
 %   DUMMY_IRS(nsamples) creates a dummy impulse response data set (Dirac
-%   impulse) to check processing without real impulse responses. It has a
-%   resolution of 1 deg for phi and theta, its length is given by nsamples.
+%   impulse) to check processing without real impulse responses. It returns only
+%   one Dirac impulse, which is then applied for all direction if you for
+%   example use it together with ir_wfs().
 %
-%   See also: SOFAgetConventions
+%   See also: SOFAgetConventions, get_ir, ir_wfs
 
 %*****************************************************************************
 % Copyright (c) 2010-2015 Quality & Usability Lab, together with             *
@@ -76,11 +78,7 @@ dirac_position = 300;
 
 
 %% ===== Computation =====================================================
-% Angles of dummy irs (in 1deg)
-theta = [-90 89];
-phi = [-180 179];
-M = length(phi)*length(theta);
-ir = zeros(M,2,nsamples);
+ir = zeros(1,2,nsamples);
 % Create dirac pulse
 ir(:,:,dirac_position) = 1;
 % Store data
@@ -95,11 +93,8 @@ sofa.GLOBAL_Comment = ['HRIR dummy set (Dirac pulse) for testing your',...
 sofa.ListenerPosition = [0 0 0];
 sofa.ListenerView = [1 0 0];
 sofa.ListenerUp = [0 0 1];
+elevation = 0;
+azimuth = 0;
 distance = dirac_position/fs*c;
-% Get angles and distance in to the correct format
-azimuth = repmat(phi,length(theta),1);
-azimuth = azimuth(:);
-elevation = repmat(theta,1,length(phi))';
-distance = distance.*ones(M,1);
 sofa.SourcePosition = [nav2sph(azimuth) elevation distance];
 sofa = SOFAupdateDimensions(sofa);

--- a/SFS_ir/dummy_irs.m
+++ b/SFS_ir/dummy_irs.m
@@ -77,8 +77,8 @@ dirac_position = 300;
 
 %% ===== Computation =====================================================
 % Angles of dummy irs (in 1deg)
-theta = -90:89;
-phi = -180:179;
+theta = [-90 89];
+phi = [-180 179];
 M = length(phi)*length(theta);
 ir = zeros(M,2,nsamples);
 % Create dirac pulse

--- a/SFS_ir/interpolate_ir.m
+++ b/SFS_ir/interpolate_ir.m
@@ -77,7 +77,7 @@ ir_new = ir(1,:,:);
 x0_new = xs;
 % Check if we have found directly the desired point or have to interpolate
 % between different impulse responses
-if norm(x0(:,1)-xs)<prec || ~useinterpolation
+if norm(x0(:,1)-xs)<prec || ~useinterpolation || size(x0,2)==1
     % Return the first nearest neighbour
     x0_new = x0(:,1);
     return;


### PR DESCRIPTION
In order to improve memory consumption and speeding up calculation I reduced the number of stored dirac pulses returned by `dummy_irs()` to only 4. It principle it should also work by using only 1, but this would need some changes in the other functions.
We could still think about if this would be worth the effort.
I tested the new version at the [example from the README](https://github.com/sfstoolbox/sfs#make-binaural-simulations-of-your-systems) and the difference between the results were <10^-18.