### PR TITLE
Change Ambisonics order for even loudspeaker numbers

### DIFF
--- a/SFS_general/nfchoa_order.m
+++ b/SFS_general/nfchoa_order.m
@@ -15,7 +15,7 @@ function M = nfchoa_order(nls,conf)
 %   the given number of secondary sources in order to avoid spectral repetitions
 %   (spatial aliasing) of the dirving signals. The order is
 %
-%        / nls/2,       even nls
+%        / nls/2 - 1,   even nls
 %   M = <
 %        \ (nls-1)/2    odd nls
 %
@@ -86,7 +86,7 @@ if strcmp('2D',dimension) || strcmp('2.5D',dimension)
     if isodd(nls)
         M = (nls-1)/2;
     else
-        M = nls/2;
+        M = nls/2 - 1;
     end
 elseif strcmp('3D',dimension)
     % Ahrens (2012), p. 125


### PR DESCRIPTION
Before it was N/2, which is not identical to the cited literature (e.g. Ahrens 2012, p. 132). There it is N/2-1, which I changed the code accordingly.
Before applying this changes: was this just a mistake, or did we choose the wrong version on purpose?