### PR TITLE
Wfsfirprefilter

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ Changes in the Sound Field Synthesis-Toolbox. Recent changes on top.
     - add new start message
     - fix handling of 0 in least squares fractional delays
     - fix NFC-HOA order for even loudspeaker numbers to N/2-1
+    - add conf.wfs.hpreFIRorder as new config option (was hard coded to 128
+      before)
 
 2.0.0 (26. October 2015)
 

--- a/SFS_config.m
+++ b/SFS_config.m
@@ -218,6 +218,8 @@ conf.wfs.hprefhigh = 1200; % / Hz
 conf.wfs.hpreBandwidth_in_Oct = 2; % / octaves
 % desired IIR filter order
 conf.wfs.hpreIIRorder = 4; % integer
+% desired FIR filter order, results in N+1 taps
+conf.wfs.hpreFIRorder = 128; % even integer
 
 
 %% ===== Spectral Division Method (SDM) ==================================

--- a/SFS_time_domain/sound_field_imp_localwfs.m
+++ b/SFS_time_domain/sound_field_imp_localwfs.m
@@ -98,14 +98,13 @@ x0 = secondary_source_positions(conf);
 % Get driving signals
 [d, x0, xv] = driving_function_imp_localwfs(x0,xs,src,conf);
 % Fix the time to account for sample offset of FIR pre-equalization filters
-% (ceiling ensures correct offset for erroneously odd order, see firls)
 if (compensate_wfs_fir_delay && compensate_local_wfs_fir_delay)
-    t = t + ceil(conf.wfs.hpreFIRorder/2) + ...
-        ceil(conf.localsfs.wfs.hpreFIRorder/2) - 1;
+    t = t + conf.wfs.hpreFIRorder/2 + ...
+        conf.localsfs.wfs.hpreFIRorder/2 - 1;
 elseif compensate_wfs_fir_delay
-    t = t + ceil(conf.wfs.hpreFIRorder/2);
+    t = t + conf.wfs.hpreFIRorder/2;
 elseif compensate_local_wfs_fir_delay
-    t = t + ceil(conf.local.wfs.hpreFIRorder/2);
+    t = t + conf.local.wfs.hpreFIRorder/2;
 end
 % Calculate sound field
 [varargout{1:min(nargout,4)}] = ...

--- a/SFS_time_domain/sound_field_imp_wfs.m
+++ b/SFS_time_domain/sound_field_imp_wfs.m
@@ -98,9 +98,8 @@ x0 = secondary_source_tapering(x0,conf);
 d = driving_function_imp_wfs(x0,xs,src,conf);
 % Fix the time to account for sample offset of FIR pre-equalization filter
 if usehpre && strcmp(hpretype,'FIR')
-    % add a time offset due to the linear phase filter,
-    % (ceiling ensures correct offset for erroneously odd order, see firls)
-    t = t + ceil(hpreFIRorder/2);
+    % add a time offset due to the linear phase filter
+    t = t + hpreFIRorder/2;
 end
 % Calculate sound field
 [varargout{1:min(nargout,4)}] = ...

--- a/SFS_time_domain/sound_field_imp_wfs.m
+++ b/SFS_time_domain/sound_field_imp_wfs.m
@@ -86,7 +86,8 @@ else
     greens_function = 'ps';
 end
 usehpre = conf.wfs.usehpre;
-
+hpretype = conf.wfs.hpretype;
+hpreFIRorder = conf.wfs.hpreFIRorder;
 
 %% ===== Computation =====================================================
 % Get secondary sources
@@ -95,11 +96,11 @@ x0 = secondary_source_selection(x0,xs,src);
 x0 = secondary_source_tapering(x0,conf);
 % Get driving signals
 d = driving_function_imp_wfs(x0,xs,src,conf);
-% Fix the time to account for sample offset of the pre-equalization filter
-if usehpre
-    % add a time offset due to the filter (the filter has 128 coefficients,
-    % hence the offset is 64 samples)
-    t = t + 64;
+% Fix the time to account for sample offset of FIR pre-equalization filter
+if usehpre && strcmp(hpretype,'FIR')
+    % add a time offset due to the linear phase filter,
+    % (ceiling ensures correct offset for erroneously odd order, see firls)
+    t = t + ceil(hpreFIRorder/2);
 end
 % Calculate sound field
 [varargout{1:min(nargout,4)}] = ...

--- a/SFS_time_domain/wfs_fir_prefilter.m
+++ b/SFS_time_domain/wfs_fir_prefilter.m
@@ -67,11 +67,9 @@ flow = conf.wfs.hpreflow;   % Lower frequency limit of preequalization
                             % filter (= frequency when subwoofer is active)
 fhigh = conf.wfs.hprefhigh; % Upper frequency limit of preequalization
                             % filter (= aliasing frequency of system)
-
+Nfilt=conf.wfs.hpreFIRorder;% Number of coefficients for filter
 
 %% ===== Variables ======================================================
-% Number of coefficients for filter
-Nfilt=128;
 % Frequency axis
 f = linspace(0,fs/2,fs/10);
 % Find indices for frequencies in f smaller and nearest to fhigh and flow
@@ -115,5 +113,3 @@ H(1:idxflow) = H(idxflow)*ones(1,idxflow);
 % Compute filter
 hpre = firls(Nfilt,2*f/fs,H);
 
-% Truncate length to power of 2
-hpre = hpre(1:end-1);

--- a/SFS_time_domain/wfs_fir_prefilter.m
+++ b/SFS_time_domain/wfs_fir_prefilter.m
@@ -68,7 +68,10 @@ flow = conf.wfs.hpreflow;      % Lower frequency limit of preequalization
 fhigh = conf.wfs.hprefhigh;    % Upper frequency limit of preequalization
                                % filter (= aliasing frequency of system)
 Nfilt = conf.wfs.hpreFIRorder; % Number of coefficients for filter
-
+if isodd(Nfilt)
+    error(['%s: conf.wfs.hpreFIRorder == %i is not a valid filter order. ', ...
+        'Must be an even integer.'],upper(mfilename),Nfilt);
+end
 %% ===== Variables ======================================================
 % Frequency axis
 f = linspace(0,fs/2,fs/10);
@@ -105,7 +108,7 @@ elseif strcmp('3D',dimension) || strcmp('2D',dimension)
     %
     H(idxflow:idxfhigh) = f(idxflow:idxfhigh)./fhigh;
 else
-    error('%s: %s is not a valid conf.dimension entry',upper(mfilename));
+    error('%s: %s is not a valid conf.dimension entry',upper(mfilename),dimension);
 end
 % Set the response for idxf < idxflow to the value at idxflow
 H(1:idxflow) = H(idxflow)*ones(1,idxflow);

--- a/SFS_time_domain/wfs_fir_prefilter.m
+++ b/SFS_time_domain/wfs_fir_prefilter.m
@@ -61,13 +61,13 @@ isargstruct(conf);
 
 
 %% ===== Configuration ==================================================
-fs = conf.fs;               % Sampling rate
-dimension = conf.dimension; % dimensionality
-flow = conf.wfs.hpreflow;   % Lower frequency limit of preequalization
-                            % filter (= frequency when subwoofer is active)
-fhigh = conf.wfs.hprefhigh; % Upper frequency limit of preequalization
-                            % filter (= aliasing frequency of system)
-Nfilt=conf.wfs.hpreFIRorder;% Number of coefficients for filter
+fs = conf.fs;                  % Sampling rate
+dimension = conf.dimension;    % dimensionality
+flow = conf.wfs.hpreflow;      % Lower frequency limit of preequalization
+                               % filter (= frequency when subwoofer is active)
+fhigh = conf.wfs.hprefhigh;    % Upper frequency limit of preequalization
+                               % filter (= aliasing frequency of system)
+Nfilt = conf.wfs.hpreFIRorder; % Number of coefficients for filter
 
 %% ===== Variables ======================================================
 % Frequency axis


### PR DESCRIPTION
### Variable FIR prefilter order for time-domain WFS 
fixes #52

* Prefilter FIR order ist stored in `conf.wfs.hpreFIRorder` 
* shall be an even integer M, resulting in a filter of length M+1
* default is M = 128
* for odd M, M+1 is used and `firls()` in `wfs_fir_prefilter()` issues a warning
  * time alignment in `sound_field_imp_wfs()` and `sound_field_imp_localwfs()` will be correct nonetheless

### Change from previous behaviour:

* previously: fixed M=128 was used and the IR's last sample was discarded, resulting in a filter length of 2^7
* now: default setting uses the full length 2^7 + 1 
* rationale:
  * I found the truncation a bit of a hack.
  * I don't see any point in having a power-of-2 filter: 
`convolution()` is not partitioned and the length should be dominated by the wfs delays for reasonable M, `conf.N` and SSD setups.
  * difference in magnitude is around -60db.

### Remarks:

* `conf.localsfs.wfs` can use its own `hpreFIRorder`, (is accounted for in `sound_field_imp_localwfs()`) 
* `sound_field_imp_wfs()` and `sound_field_imp_localwfs()` compensate the prefilter delay only if the FIR filter is used.
(The IIR filter should be minimum phase.)
