### PR TITLE
Correct sign in NFC-HOA time domain driving function

### DIFF
--- a/SFS_time_domain/driving_function_imp_nfchoa.m
+++ b/SFS_time_domain/driving_function_imp_nfchoa.m
@@ -80,14 +80,7 @@ order = nfchoa_order(nls,conf);
 
 % Correct position of source for off-center arrays
 xs(1:3) = xs(1:3)-X0;
-% If-request as a workaround for the right direction of the sound field
-if strcmpi(src,'pw')
-    [theta_src, r_src] = cart2pol(-xs(1),xs(2));
-elseif strcmpi(src,'ps')
-    [theta_src, r_src] = cart2pol(xs(1),-xs(2));
-else
-    [theta_src, r_src] = cart2pol(xs(1),xs(2));
-end
+[theta_src, r_src] = cart2pol(xs(1),xs(2));
 
 % Compute impulse responses of modal filters
 dm = zeros(order+1,N);
@@ -121,7 +114,7 @@ end
 % Compute input signal for IFFT
 d = zeros(2*order+1,N);
 for n=-order:order
-    d(n+order+1,:) = dm(abs(n)+1,:) .* exp(1i*n*theta_src);
+    d(n+order+1,:) = dm(abs(n)+1,:) .* exp(-1i*n*theta_src);
 end
 
 if(iseven(nls))

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ps.m
@@ -100,7 +100,7 @@ elseif strcmp('2.5D',dimension)
         %
         [sos,~] = zp2sos(z*c/r,z*c/R,1,'up','none');
         %
-        % compare Spors et al. (2011)
+        % compare Spors et al. (2011), eq. (11)
         %
     else
         error(['%s: %s, this type of driving function is not implemented', ...

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_pw.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_pw.m
@@ -98,8 +98,9 @@ elseif strcmp('2.5D',dimension)
         % 2.5D for a plane wave as source model
         %
         [sos,~] = zp2sos(p,z*c/R,2,'down','none');
+        sos(1,1:3) = sos(1,1:3) * (-1)^abs(N);
         %
-        % compare Spors et al. (2011)
+        % compare Spors et al. (2011), eq. (10)
         %
     else
         error(['%s: %s, this type of driving function is not implemented', ...


### PR DESCRIPTION
I changed the NFC-HOA time domain driving function, according to #55. But there are still some problems.

Try the following commands:

```Matlab
conf = SFS_config;
conf.nfchoa.order = 32;
sound_field_imp_nfchoa([-2 2],[-2 2],0,[1 0 0],'pw',300,conf)
sound_field_imp_nfchoa([-2 2],[-2 2],0,[2.5 0 0],'ps',300,conf)
```

Here are the results from before the change:

![nfchoa_pw_before](https://cloud.githubusercontent.com/assets/173624/12552972/059f03a6-c375-11e5-9ec3-ebc202467747.png)
![nfchoa_ps_after](https://cloud.githubusercontent.com/assets/173624/12552980/16ae56ba-c375-11e5-9ba4-59c7ec7bacee.png)

And here after the changes:

![nfchoa_pw_after](https://cloud.githubusercontent.com/assets/173624/12552977/10e218ca-c375-11e5-99cb-3e63ce190a53.png)

![nfchoa_ps_before](https://cloud.githubusercontent.com/assets/173624/12552974/088311fc-c375-11e5-8646-95c16441e288.png)

As you can see, the results for the point source is still correct, but in the case of the plane wave we have no a wrong direction.
