### PR TITLE
Return wfs delay

### DIFF
--- a/SFS_time_domain/driving_function_imp_wfs.m
+++ b/SFS_time_domain/driving_function_imp_wfs.m
@@ -1,24 +1,26 @@
-function [d,delay,weight] = driving_function_imp_wfs(x0,xs,src,conf)
+function [d,delay,weight,delay_offset] = driving_function_imp_wfs(x0,xs,src,conf)
 %DRIVING_FUNCTION_IMP_WFS_25D calculates the WFS weighting and delaying
 %
 %   Usage: [d,delay,weight] = driving_function_imp_wfs(x0,xs,src,conf)
 %
 %   Input parameters:
-%       x0      - positions and directions of secondary sources / m [nx6]
-%       xs      - position of virtual source or direction of plane wave / m
-%                 [1x3]
-%       src     - source type of the virtual source
-%                     'pw' - plane wave (xs, ys are the direction of the
-%                            plane wave in this case)
-%                     'ps' - point source
-%                     'ls' - line source
-%                     'fs' - focused source
-%       conf    - configuration struct (see SFS_config)
+%       x0              - positions and directions of secondary
+%                         sources / m [nx6]
+%       xs              - position of virtual source or direction of
+%                         plane wave / m [1x3]
+%       src             - source type of the virtual source
+%                           'pw' - plane wave (xs, ys are the direction of the
+%                                  plane wave in this case)
+%                           'ps' - point source
+%                           'ls' - line source
+%                           'fs' - focused source
+%       conf            - configuration struct (see SFS_config)
 %
 %   Output parameters:
-%       d       - driving signals [mxn]
-%       delay   - delay of the driving function / s [nx1]
-%       weight  - weight (amplitude) of the driving function [nx1]
+%       d               - driving signals [mxn]
+%       delay           - delay of the driving function / s [nx1]
+%       weight          - weight (amplitude) of the driving function [nx1]
+%       delay_offset    - additional added delay, so you can correct it
 %
 %   DRIVING_FUNCTION_IMP_WFS(x0,xs,src,conf) returns the driving signals and
 %   weighting and delay parameters of the WFS driving function for the given
@@ -114,11 +116,13 @@ else
 end
 
 if removedelay
-    % Remove delay offset, in order to begin always at t=0 with the first wave front
-    % at any secondary source
-    delay = delay-min(delay);
+    % Set minimum delay to 0, in order to begin always at t=0 with the first
+    % wave front at any secondary source
+    delay = delay - min(delay);
+    % Return extra offset due to prefilter
+    delay_offset = prefilter_delay;
 else
-    % Delay to ensure causality at all secondary sources
+    % Add extra delay to ensure causality at all secondary sources (delay>0)
     [diameter,center] = secondary_source_diameter(conf);
     t0 = diameter/c;
     if (ceil((max(delay)+t0)*fs) - 1 ) > N
@@ -134,8 +138,10 @@ else
                 'spanned by the array diameter.'],upper(mfilename));
         end
     end
-    % Ensure virtual source start activity at t=0
-    delay = delay + t0 + prefilter_delay;
+    delay = delay + t0;
+    % Return extra added delay. This is can be used to ensure that the virtual
+    % source always starts at t = 0.
+    delay_offset = t0 + prefilter_delay;
 end
 % Append zeros at the end of the driving function. This is necessary, because
 % the delayline function cuts into the end of the driving signals in order to

--- a/SFS_time_domain/driving_function_imp_wfs.m
+++ b/SFS_time_domain/driving_function_imp_wfs.m
@@ -78,7 +78,7 @@ removedelay = conf.wfs.removedelay;
 
 %% ===== Computation =====================================================
 % Calculate pre-equalization filter if required
-pulse = wfs_preequalization(dirac_imp(),conf);
+[pulse,prefilter_delay] = wfs_preequalization(dirac_imp(),conf);
 
 % Secondary source positions and directions
 nx0 = x0(:,4:6);
@@ -134,7 +134,8 @@ else
                 'spanned by the array diameter.'],upper(mfilename));
         end
     end
-    delay = delay + t0;
+    % Ensure virtual source start activity at t=0
+    delay = delay + t0 + prefilter_delay;
 end
 % Append zeros at the end of the driving function. This is necessary, because
 % the delayline function cuts into the end of the driving signals in order to

--- a/SFS_time_domain/sound_field_imp_wfs.m
+++ b/SFS_time_domain/sound_field_imp_wfs.m
@@ -88,6 +88,9 @@ end
 usehpre = conf.wfs.usehpre;
 hpretype = conf.wfs.hpretype;
 hpreFIRorder = conf.wfs.hpreFIRorder;
+c = conf.c;
+fs = conf.fs;
+
 
 %% ===== Computation =====================================================
 % Get secondary sources
@@ -95,12 +98,9 @@ x0 = secondary_source_positions(conf);
 x0 = secondary_source_selection(x0,xs,src);
 x0 = secondary_source_tapering(x0,conf);
 % Get driving signals
-d = driving_function_imp_wfs(x0,xs,src,conf);
-% Fix the time to account for sample offset of FIR pre-equalization filter
-if usehpre && strcmp(hpretype,'FIR')
-    % add a time offset due to the linear phase filter
-    t = t + hpreFIRorder/2;
-end
+[d,~,~,delay_offset] = driving_function_imp_wfs(x0,xs,src,conf);
+% Ensure virtual source/secondary source activity starts at t = 0
+t = t + delay_offset*fs;
 % Calculate sound field
 [varargout{1:min(nargout,4)}] = ...
     sound_field_imp(X,Y,Z,x0,greens_function,d,t,conf);

--- a/SFS_time_domain/wfs_preequalization.m
+++ b/SFS_time_domain/wfs_preequalization.m
@@ -80,16 +80,21 @@ if strcmp('FIR',conf.wfs.hpretype)
     % Delay in s added by filter
     delay = conf.wfs.hpreFIRorder/2 / fs;
 elseif strcmp('IIR',conf.wfs.hpretype)
+    if len_ir == 1
+        % Happens when called from driving_function_imp_wfs()
+        % Zeropadding to length conf.N
+       ir = [ir; zeros(conf.N-1,size(ir,2))];
+    end
     % Get IIR filter
     hpre = wfs_iir_prefilter(conf);
     % Apply filter
-    ir = filter(hpre.b,hpre.a,ir,2);
-    % Delay in s added by filter
-    delay = conf.wfs.hpreIIRorder/2 / fs;
+    ir = sosfilt(hpre.sos,ir,1);
+    % IIR is minimum phase, so no proper delay introduced
+    delay = 0;
 else
     error('%s: %s is an unknown filter type.',upper(mfilename),hpretype);
 end
 % Correct length of ir
-if len_ir>length(hpre)+1
+if strcmp('FIR',conf.wfs.hpretype) && (len_ir>length(hpre)+1)
     ir = ir(1:len_ir,:);
 end

--- a/SFS_time_domain/wfs_preequalization.m
+++ b/SFS_time_domain/wfs_preequalization.m
@@ -1,19 +1,21 @@
-function ir = wfs_preequalization(ir,conf)
+function [ir,delay] = wfs_preequalization(ir,conf)
 %WFS_PREEQUALIZATION applies a pre-equalization filter for WFS
 %
 %   Usage: ir = wfs_preequalization(ir,conf)
 %
 %   Input parameters:
-%       ir      - IR to which the pre-equalization filter should be applied
+%       ir      - signal to which the pre-equalization filter should be applied
 %       conf    - configuration struct (see SFS_config)
 %
 %   Output parameters:
-%       ir      - IR with applied pre-equalization
+%       ir      - signal with applied pre-equalization
+%       delay   - additional delay added by pre-equalization
+%
 %
 %   WFS_PREEQUALIZATION(ir,conf) applies the pre-equalization filter for
 %   Wave Field Synthesis to the given impulse response.
 %
-%   See also: wfs_fir_prefilter, wfs_iir_prefilter, ir_wfs
+%   See also: wfs_fir_prefilter, wfs_iir_prefilter, driving_function_imp_wfs
 
 %*****************************************************************************
 % Copyright (c) 2010-2016 Quality & Usability Lab, together with             *
@@ -58,11 +60,13 @@ isargstruct(conf);
 
 %% ===== Configuration ==================================================
 usehpre = conf.wfs.usehpre;
+fs = conf.fs;
 
 
 %% ===== Computation =====================================================
 % Check if we should procide
 if ~usehpre
+    delay = 0;
     return;
 end
 % Store original length
@@ -73,11 +77,15 @@ if strcmp('FIR',conf.wfs.hpretype)
     hpre = wfs_fir_prefilter(conf);
     % Apply filter
     ir = convolution(hpre,ir);
+    % Delay in s added by filter
+    delay = conf.wfs.hpreFIRorder/2 / fs;
 elseif strcmp('IIR',conf.wfs.hpretype)
     % Get IIR filter
     hpre = wfs_iir_prefilter(conf);
     % Apply filter
     ir = filter(hpre.b,hpre.a,ir,2);
+    % Delay in s added by filter
+    delay = conf.wfs.hpreIIRorder/2 / fs;
 else
     error('%s: %s is an unknown filter type.',upper(mfilename),hpretype);
 end

--- a/validation/test_driving_functions_imp_with_delay.m
+++ b/validation/test_driving_functions_imp_with_delay.m
@@ -97,7 +97,7 @@ for ii=1:size(scenarios)
 
     % get current dimension
     conf.dimension = scenarios{ii,2};
-   
+
     % get listening area
     switch scenarios{ii,3}
         case 'linear'
@@ -127,11 +127,18 @@ for ii=1:size(scenarios)
     end
 
     conf.secondary_sources.geometry = scenarios{ii,3};
-    t0 = secondary_source_diameter(conf)/conf.c; % max. travel time
-    total_delay = round(t0*conf.fs) + conf.wfs.hpreFIRorder/2;
-    t = total_delay + 30;        % some samples more to see the point source
+    t = scenarios{ii,5};
     src = scenarios{ii,4};
     xs = scenarios{ii,5};
+    % Adjust time for different source types (t=0 corresponds to first activity
+    % of virtual source).
+    if strcmp('ps',src) || strcmp('ls',src)
+        t = 2 / conf.c * conf.fs;   % time for traveling 2 m
+    elseif strcmp('fs',src)
+        t = 0.5 / conf.c * conf.fs; % time for traveling 0.5 m
+    else
+        t = 0;
+    end
 
     % ===== WFS ==========================================================
     % spatio-temporal impulse response
@@ -149,5 +156,5 @@ for ii=1:size(scenarios)
             upper(mfilename),conf.secondary_sources.geometry,conf.dimension,src);
         lasterr
     end
-    
+
 end


### PR DESCRIPTION
This is a follow up on #59.

The main goal was fomulated by @fietew as:

> Imho, it would be easier to return the pre-delay which has been added to the driving function by a particular processing step, e.g. fractional delay, wfs prefilter, focused source, plane wave, etc..
Furthermore, I would prefer that t=0 corresponds to the t=0 of the virtual source, i.e. where the sound "starts" to radiate from a point/focused source or when the plane wave passed its point of zero phase.

In order to achieve this I did the following things:

1. Add an additional `prefilter_delay` return parameter to `wfs_preequalization()`, which returns the delay that is added by the applied pre-filter.
2. Add an additional `delay_offset` return parameter to `driving_function_imp_wfs()`. In the case of `conf.removedelay=1` it returns `prefilter_delay`. In the case of `conf.wfs.removedelay=0` it returns `secondary_source_diameter(conf)/c + prefilter_delay`
3. I used this directly in `sound_field_imp_wfs()`:
```Matlab
[d,~,~,delay_offset] = driving_function_imp_wfs(x0,xs,src,conf);
t = t + delay_offset*fs;
```

**Result**
That means if you use `sound_field_imp_wfs()` with `conf.wfs.removedelay=1` you will have the first activity at the secondary sources for `t = 0`. With `conf.wfs.removedelay=0` you will have the first activity of the virtual sources for `t = 0`.

**Example**
```Matlab
conf = SFS_config;
conf.wfs.removedelay = 1;
conf.plot.usedb = 1;
sound_field_imp_wfs([-2 2],[-2 2],0,[0 0.5 0 0 -1 0],'fs',0,conf)
```

![wfs_fs_removedelay1](https://cloud.githubusercontent.com/assets/173624/12841882/654b3662-cbef-11e5-888b-814a0abf6279.png)

```Matlab
conf = SFS_config;
conf.wfs.removedelay = 0;
conf.plot.usedb = 1;
sound_field_imp_wfs([-2 2],[-2 2],0,[0 0.5 0 0 -1 0],'fs',0,conf)
```

![wfs_fs_removedelay0](https://cloud.githubusercontent.com/assets/173624/12841899/7c5b0ef4-cbef-11e5-8c42-411230759606.png)

**Open questions**

- @fietew : as you can see I have only added the return value to the driving function, not to the delayline etc. Could you maybe add it to the other functions?
- @trettberg : I have added a [return value also for the IIR filter](https://github.com/sfstoolbox/sfs/blob/return_wfs_delay/SFS_time_domain/wfs_preequalization.m#L88) with `delay = conf.wfs.hpreIIRorder/2 / fs;` I guess this is not correct, could you please correct it.
