### PR TITLE
fix handling of edges for tapering window

### DIFF
--- a/SFS_general/tapering_window.m
+++ b/SFS_general/tapering_window.m
@@ -97,9 +97,9 @@ if usetapwin && nls>2 && ...
     % If we have any edges in our array apply a tapering window for every array
     % part, consisting of two edges
     if ~isempty(edges)
-        edges = sort(edges);
-        if edges(1)==1
+        if edges(end)==1
             % First and last entry of secondary source is an edge
+            edges = circshift(edges,1,1);
             start_idx = 1;
         else
             % First and last entry of secondary source is not an edge

--- a/SFS_time_domain/driving_function_imp_nfchoa.m
+++ b/SFS_time_domain/driving_function_imp_nfchoa.m
@@ -75,7 +75,6 @@ X0 = conf.secondary_sources.center;
 pulse = dirac_imp();
 % Radius of array
 R = norm(x0(1,1:3)-X0); 
-R = conf.secondary_sources.size/2;
 % Ambisonics order
 if isempty(conf.nfchoa.order)
     % Get maximum order of spherical harmonics


### PR DESCRIPTION
See https://github.com/sfstoolbox/sfs/commit/c8fec3ef82435a90c4d0a42cdb04e3de039d4566#diff-f9229d5f60cedf852a470bd907a2ac05R103 . 

The if clause in the current implementation incorrectly recognizes `edges=[1,2]` as `edges=[end,1]`