### PR TITLE
Fix 3D-WFS time domain driving function for virtual line source

### DIFF
--- a/SFS_time_domain/driving_function_imp_wfs.m
+++ b/SFS_time_domain/driving_function_imp_wfs.m
@@ -87,7 +87,7 @@ nx0 = x0(:,4:6);
 x0 = x0(:,1:3);
 
 % Source position
-xs = repmat(xs(1:3),[size(x0,1) 1]);
+xs = repmat(xs,[size(x0,1) 1]);
 
 % Get the delay and weighting factors
 if strcmp('pw',src)


### PR DESCRIPTION
This uses the correct distance from virtual line source to secondary sources.
(We fixed the mono-frequent case some weeks ago. This is just the same for the impulsive case.)