### PR TITLE
Add automatic scaling to loudspeaker weights for plotting

### DIFF
--- a/SFS_plotting/draw_loudspeakers.m
+++ b/SFS_plotting/draw_loudspeakers.m
@@ -13,7 +13,8 @@ function draw_loudspeakers(x0,dimensions,conf)
 %   DRAW_LOUDSPEAKERS(x0,dimensions,conf) draws loudspeaker symbols or filled
 %   points at the given secondary source positions. This can be controlled by
 %   the conf.plot.realloudspeakers setting. The loudspeaker symbols are pointing
-%   in their given direction.
+%   in their given direction and are colored accordingly to their weights,
+%   whereby the weights are scaled to an absolute maximum of 1 before.
 %
 %   See also: plot_sound_field
 
@@ -78,42 +79,41 @@ elseif ~dimensions(2)
     x0(:,2) = x0(:,3);
 end
 
-% Weightings of the single sources (scale maximum to 1)
-win = x0(:,7) / max(x0(:,7));
-
-% Plot only "x" at the loudspeaker positions, use this as default for all cases
+% Plot only "o" at the loudspeaker positions, use this as default for all cases
 % that are not the x-y-plane
 if ~p.realloudspeakers || ~(dimensions(1)&&dimensions(2))
+
     if p.realloudspeakers && ~(dimensions(1)&&dimensions(2))
         warning('%s: Real loudspeaker can only be drawn in the x-y-plane', ...
             upper(mfilename));
     end
-    % plot all secondary sources with the same color + symbol
+    % Plot all secondary sources with the same color + symbol
     plot(x0(:,1),x0(:,2),'o', ...
         'MarkerFaceColor','k', ...
         'MarkerEdgeColor','k', ...
         'MarkerSize',4);
-else
-    % Set fill color for active loudspeakers
-    % Scale the color. sc = 1 => black. sc = 0.5 => gray.
-    sc = 0.6;
-    fc = [(1-sc.*win), ...
-          (1-sc.*win), ...
-          (1-sc.*win)];
 
-    w = p.lssize;
-    h = p.lssize;
+else
+
+    % Weightings of the single loudspeakers (scale maximum to 1)
+    weights = x0(:,7) / max(abs(x0(:,7)));
+    % Set fill color for active loudspeakers
+    % Scale the color: sc = 1 => black, sc = 0.5 => gray.
+    sc = 0.6;
+    fc = [(1-sc.*weights), ...
+          (1-sc.*weights), ...
+          (1-sc.*weights)];
 
     % Plot a real speaker symbol at the desired position
-    % vertex coordinates
-    %v1 = [-h/2 -h/2 0 0 -h/2 ; -w/2 w/2 w/2 -w/2 -w/2];
-    %v2 = [0 h/2 h/2 0 ; -w/6 -w/2 w/2 w/6];
+    % vertex coordinates with height and width after lssize
+    w = p.lssize;
+    h = p.lssize;
     v1 = [-h -h -h/2 -h/2 -h ; -w/2 w/2 w/2 -w/2 -w/2 ; 0 0 0 0 0];
     v2 = [-h/2 0 0 -h/2 ; -w/6 -w/2 w/2 w/6 ; 0 0 0 0 ];
 
     hold on;
 
-    % draw loudspeakers
+    % Draw loudspeakers
     for n=1:nls
 
         % Get the azimuth direction of the secondary sources
@@ -122,23 +122,20 @@ else
         % Rotation matrix (orientation of the speakers)
         % R = [cos(phi(n)) -sin(phi(n));sin(phi(n)) cos(phi(n))];
         R = rotation_matrix(phi);
-
         for k=1:length(v1)
             vr1(:,k) = R * v1(:,k);
         end
-
         for k=1:length(v2)
             vr2(:,k) = R * v2(:,k);
         end
 
-        % shift
+        % Shift
         v01(1,:) = vr1(1,:) + x0(n,1);
         v01(2,:) = vr1(2,:) + x0(n,2);
         v02(1,:) = vr2(1,:) + x0(n,1);
         v02(2,:) = vr2(2,:) + x0(n,2);
 
-
-        % Draw speakers
+        % Draw loudspeakers
         fill(v01(1,:),v01(2,:),fc(n,:));
         fill(v02(1,:),v02(2,:),fc(n,:));
 

--- a/SFS_plotting/draw_loudspeakers.m
+++ b/SFS_plotting/draw_loudspeakers.m
@@ -78,8 +78,8 @@ elseif ~dimensions(2)
     x0(:,2) = x0(:,3);
 end
 
-% Weightings of the single sources
-win = x0(:,7);
+% Weightings of the single sources (scale maximum to 1)
+win = x0(:,7) / max(x0(:,7));
 
 % Plot only "x" at the loudspeaker positions, use this as default for all cases
 % that are not the x-y-plane


### PR DESCRIPTION
With 7b46fff0839585b595f88a95ffc84e5fb3c2f9b8￼ we introduced a new weighting to the loudspeakers, which results in relatively low values (<<1) for standard setups. This is of course not a problem, but has a small effect on the plotting of real loudspeaker symbols as those are colored accordingly to the absolute weight of the loudspeaker.

Here is an example from the current master:
```Matlab
conf = SFS_config;
conf.plot.normalisation = 'center';
conf.plot.realloudspeakers = 1;
sound_field_mono_wfs([-2 2],[-2 2],0,[0 2.5 0],'ps',800,conf)
```

![ls_w_old](https://cloud.githubusercontent.com/assets/173624/14825710/400edd8c-0bdb-11e6-9d01-eacbabc160ed.png)

As you can see more or less all loudspeakers are white.

In this pull request I added an automatic scaling of the loudspeakers (that the maximum weight to 1) to the `draw_loudspeaker` function, which results in this plot by executing the same commands as above.

![ls_w_new](https://cloud.githubusercontent.com/assets/173624/14825744/67e2a820-0bdb-11e6-9d4f-8f5912425864.png)

I'm not sure yet if this is the best solution for more complex cases, but I think it is better than before.