### PR TITLE
improve check for old config struct

### DIFF
--- a/SFS_ir/interpolate_ir.m
+++ b/SFS_ir/interpolate_ir.m
@@ -79,12 +79,14 @@ narginchk(nargmin,nargmax);
 %% ===== Configuration ==================================================
 useinterpolation = conf.ir.useinterpolation;
 % Check for old configuration
-if useinterpolation && ~isfield(conf.ir,'interpolationmethod')
-    warning('SFS:irs_intpolmethod',...
-        'no interpolation method provided, will use method ''simple''.');
-    interpolationmethod = 'simple';
-else
-    interpolationmethod = conf.ir.interpolationmethod;
+if useinterpolation 
+    if ~isfield(conf.ir,'interpolationmethod')
+        warning('SFS:irs_intpolmethod',...
+            'no interpolation method provided, will use method ''simple''.');
+        interpolationmethod = 'simple';
+    else
+        interpolationmethod = conf.ir.interpolationmethod;
+    end
 end
 % Precision of the wanted angle. If an impulse response within the given
 % precision could be found no interpolation is applied.


### PR DESCRIPTION
I made a small change so that there is no error if `conf.ir.useinterpolation = false` and the field `conf.ir.interpolationmethod` does not exist.