### PR TITLE
Remove contact email address

### DIFF
--- a/SFS_HRTF_extrapolation/extrapolate_farfield_hrtfset.m
+++ b/SFS_HRTF_extrapolation/extrapolate_farfield_hrtfset.m
@@ -49,7 +49,7 @@ function sofa_pw = extrapolate_farfield_hrtfset(sofa,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/freq_response_line_source.m
+++ b/SFS_analysis/freq_response_line_source.m
@@ -44,7 +44,7 @@ function varargout = freq_response_line_source(X,xs,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/freq_response_localwfs_sbl.m
+++ b/SFS_analysis/freq_response_localwfs_sbl.m
@@ -51,7 +51,7 @@ function varargout = freq_response_localwfs_sbl(X,xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/freq_response_localwfs_vss.m
+++ b/SFS_analysis/freq_response_localwfs_vss.m
@@ -51,7 +51,7 @@ function varargout = freq_response_localwfs_vss(X,xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/freq_response_nfchoa.m
+++ b/SFS_analysis/freq_response_nfchoa.m
@@ -51,7 +51,7 @@ function varargout = freq_response_nfchoa(X,xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/freq_response_point_source.m
+++ b/SFS_analysis/freq_response_point_source.m
@@ -44,7 +44,7 @@ function varargout = freq_response_point_source(X,xs,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/freq_response_wfs.m
+++ b/SFS_analysis/freq_response_wfs.m
@@ -51,7 +51,7 @@ function varargout = freq_response_wfs(X,xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/time_response_line_source.m
+++ b/SFS_analysis/time_response_line_source.m
@@ -45,7 +45,7 @@ function varargout = time_response_line_source(X,xs,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/time_response_localwfs_sbl.m
+++ b/SFS_analysis/time_response_localwfs_sbl.m
@@ -52,7 +52,7 @@ function varargout = time_response_localwfs_sbl(X,xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/time_response_localwfs_vss.m
+++ b/SFS_analysis/time_response_localwfs_vss.m
@@ -52,7 +52,7 @@ function varargout = time_response_localwfs_vss(X,xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/time_response_nfchoa.m
+++ b/SFS_analysis/time_response_nfchoa.m
@@ -52,7 +52,7 @@ function varargout = time_response_nfchoa(X,xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/time_response_point_source.m
+++ b/SFS_analysis/time_response_point_source.m
@@ -47,7 +47,7 @@ function varargout = time_response_point_source(X,xs,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/time_response_wfs.m
+++ b/SFS_analysis/time_response_wfs.m
@@ -52,7 +52,7 @@ function varargout = time_response_wfs(X,xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_analysis/wave_fronts_wfs.m
+++ b/SFS_analysis/wave_fronts_wfs.m
@@ -57,7 +57,7 @@ function varargout = wave_fronts_wfs(X,phi,xs,src,gnuplot,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_binaural_synthesis/auralize_ir.m
+++ b/SFS_binaural_synthesis/auralize_ir.m
@@ -45,7 +45,7 @@ function outsig = auralize_ir(ir,content,usenorm,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_binaural_synthesis/compensate_headphone.m
+++ b/SFS_binaural_synthesis/compensate_headphone.m
@@ -45,7 +45,7 @@ function ir = compensate_headphone(ir,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_binaural_synthesis/ir_generic.m
+++ b/SFS_binaural_synthesis/ir_generic.m
@@ -49,7 +49,7 @@ function ir = ir_generic(X,head_orientation,x0,d,sofa,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_binaural_synthesis/ir_localwfs.m
+++ b/SFS_binaural_synthesis/ir_localwfs.m
@@ -50,7 +50,7 @@ function [ir,x0] = ir_localwfs(X,head_orientation,xs,src,sofa,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_binaural_synthesis/ir_nfchoa.m
+++ b/SFS_binaural_synthesis/ir_nfchoa.m
@@ -51,7 +51,7 @@ function [ir,x0,delay] = ir_nfchoa(X,head_orientation,xs,src,sofa,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_binaural_synthesis/ir_point_source.m
+++ b/SFS_binaural_synthesis/ir_point_source.m
@@ -47,7 +47,7 @@ function ir = ir_point_source(X,head_orientation,xs,sofa,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_binaural_synthesis/ir_wfs.m
+++ b/SFS_binaural_synthesis/ir_wfs.m
@@ -52,7 +52,7 @@ function [ir,x0,delay] = ir_wfs(X,head_orientation,xs,src,sofa,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_config.m
+++ b/SFS_config.m
@@ -41,7 +41,7 @@ function conf = SFS_config()
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/aliasing_frequency.m
+++ b/SFS_general/aliasing_frequency.m
@@ -58,7 +58,7 @@ function [fal,dx0] = aliasing_frequency(x0,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/asslegendre.m
+++ b/SFS_general/asslegendre.m
@@ -39,7 +39,7 @@ function [ Lnm ] = asslegendre(n,m,arg)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/bandpass.m
+++ b/SFS_general/bandpass.m
@@ -40,7 +40,7 @@ function sig =  bandpass(sig,flow,fhigh,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/bilinear_transform.m
+++ b/SFS_general/bilinear_transform.m
@@ -41,7 +41,7 @@ function [b,a] = bilinear_transform(sos,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/check_dimensionality.m
+++ b/SFS_general/check_dimensionality.m
@@ -50,7 +50,7 @@ function [x0, xs, dim, eq_idx] = check_dimensionality(x0, xs, tol, gamma)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/cm2in.m
+++ b/SFS_general/cm2in.m
@@ -37,7 +37,7 @@ function y = cm2in(x)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/cm2px.m
+++ b/SFS_general/cm2px.m
@@ -37,7 +37,7 @@ function y = cm2px(x)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/column_vector.m
+++ b/SFS_general/column_vector.m
@@ -37,7 +37,7 @@ function varargout = column_vector(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/convolution.m
+++ b/SFS_general/convolution.m
@@ -44,7 +44,7 @@ function z = convolution(x,y)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/correct_azimuth.m
+++ b/SFS_general/correct_azimuth.m
@@ -37,7 +37,7 @@ function phi = correct_azimuth(phi)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/correct_elevation.m
+++ b/SFS_general/correct_elevation.m
@@ -37,7 +37,7 @@ function delta = correct_elevation(delta)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/deg.m
+++ b/SFS_general/deg.m
@@ -37,7 +37,7 @@ function phi = deg(phi)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/delayline.m
+++ b/SFS_general/delayline.m
@@ -56,7 +56,7 @@ function [sig,delay_offset] = delayline(sig,dt,weight,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/direction_vector.m
+++ b/SFS_general/direction_vector.m
@@ -38,7 +38,7 @@ function directions = direction_vector(x1,x2)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/download_file.m
+++ b/SFS_general/download_file.m
@@ -41,7 +41,7 @@ function success = download_file(url,outfile)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/findcols.m
+++ b/SFS_general/findcols.m
@@ -42,7 +42,7 @@ function k = findcols(A,b)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 % AUTHOR: Peter John Acklam

--- a/SFS_general/findconvexcone.m
+++ b/SFS_general/findconvexcone.m
@@ -50,7 +50,7 @@ function [idx,weights] = findconvexcone(x0,xs)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/findnearestneighbour.m
+++ b/SFS_general/findnearestneighbour.m
@@ -44,7 +44,7 @@ function [idx,weights] = findnearestneighbour(A,b,N)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/findrows.m
+++ b/SFS_general/findrows.m
@@ -42,7 +42,7 @@ function k = findrows(A,b)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 % AUTHOR: Peter John Acklam

--- a/SFS_general/findvoronoi.m
+++ b/SFS_general/findvoronoi.m
@@ -43,7 +43,7 @@ function [idx,weights] = findvoronoi(x0,xs)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/fix_length.m
+++ b/SFS_general/fix_length.m
@@ -41,7 +41,7 @@ function sig = fix_length(sig,N)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/gaindb.m
+++ b/SFS_general/gaindb.m
@@ -38,7 +38,7 @@ function inoutsig = gaindb(inoutsig,gn)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/general_least_squares.m
+++ b/SFS_general/general_least_squares.m
@@ -47,7 +47,7 @@ function h = general_least_squares(samples,fractional_delay,passband_edge)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/get_shelve_lagrange.m
+++ b/SFS_general/get_shelve_lagrange.m
@@ -67,7 +67,7 @@ function H = get_shelve_lagrange(f,H,FlagSub,fSub,FlagAliasing,fAliasing,Bandwid
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 % Revision: 07/02/2013 frank.schultz@uni-rostock.de initial development      *
 %*****************************************************************************
     Hphase = unwrap(angle(H));  %save original phase

--- a/SFS_general/get_spherical_grid.m
+++ b/SFS_general/get_spherical_grid.m
@@ -56,7 +56,7 @@ function [points,weights] = get_spherical_grid(number,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/hann_window.m
+++ b/SFS_general/hann_window.m
@@ -40,7 +40,7 @@ function win = hann_window(onset,offset,nsamples)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/in2cm.m
+++ b/SFS_general/in2cm.m
@@ -37,7 +37,7 @@ function y = in2cm(x)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/in2px.m
+++ b/SFS_general/in2px.m
@@ -37,7 +37,7 @@ function y = in2px(x)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/inverse_cht.m
+++ b/SFS_general/inverse_cht.m
@@ -40,7 +40,7 @@ function [A,Phi] = inverse_cht(Am,Nphi)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/inverse_lt.m
+++ b/SFS_general/inverse_lt.m
@@ -38,7 +38,7 @@ function A = inverse_lt(Am,x)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/is_dim_custom.m
+++ b/SFS_general/is_dim_custom.m
@@ -41,7 +41,7 @@ function bool = is_dim_custom(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/is_dim_singleton.m
+++ b/SFS_general/is_dim_singleton.m
@@ -38,7 +38,7 @@ function bool = is_dim_singleton(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/iseven.m
+++ b/SFS_general/iseven.m
@@ -37,7 +37,7 @@ function bool = iseven(number)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/ismonoinc.m
+++ b/SFS_general/ismonoinc.m
@@ -37,7 +37,7 @@ function bool = ismonoinc(x)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/isodd.m
+++ b/SFS_general/isodd.m
@@ -37,7 +37,7 @@ function bool = isodd(number)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/lagrange_filter.m
+++ b/SFS_general/lagrange_filter.m
@@ -40,7 +40,7 @@ function b = lagrange_filter(Norder,fdt)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/linkwitz_riley.m
+++ b/SFS_general/linkwitz_riley.m
@@ -46,7 +46,7 @@ function [z,p,k] = linkwitz_riley(n,wc,ftype,domain)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/modal_weighting.m
+++ b/SFS_general/modal_weighting.m
@@ -74,7 +74,7 @@ function [win,varargout] = modal_weighting(order,Ninv,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/nfchoa_order.m
+++ b/SFS_general/nfchoa_order.m
@@ -56,7 +56,7 @@ function M = nfchoa_order(nls,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/norm_signal.m
+++ b/SFS_general/norm_signal.m
@@ -37,7 +37,7 @@ function sig = norm_signal(sig)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/pm_filter.m
+++ b/SFS_general/pm_filter.m
@@ -39,7 +39,7 @@ function b = pm_filter(order,wpass,wstop)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/px2cm.m
+++ b/SFS_general/px2cm.m
@@ -37,7 +37,7 @@ function y = px2cm(x)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/px2in.m
+++ b/SFS_general/px2in.m
@@ -37,7 +37,7 @@ function y = px2in(x)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/rad.m
+++ b/SFS_general/rad.m
@@ -37,7 +37,7 @@ function phi = rad(phi)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/rotation_matrix.m
+++ b/SFS_general/rotation_matrix.m
@@ -45,7 +45,7 @@ function R = rotation_matrix(phi,dim,orientation)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/rounded_box.m
+++ b/SFS_general/rounded_box.m
@@ -63,7 +63,7 @@ function [x0,n0,w0] = rounded_box(t,ratio)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 %% ===== Checking of input  parameters =======================================

--- a/SFS_general/row_vector.m
+++ b/SFS_general/row_vector.m
@@ -37,7 +37,7 @@ function varargout = row_vector(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/secondary_source_diameter.m
+++ b/SFS_general/secondary_source_diameter.m
@@ -46,7 +46,7 @@ function [diam,center] = secondary_source_diameter(conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/secondary_source_distance.m
+++ b/SFS_general/secondary_source_distance.m
@@ -48,7 +48,7 @@ function [dx0,dx0_single] = secondary_source_distance(x0,approx)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/secondary_source_positions.m
+++ b/SFS_general/secondary_source_positions.m
@@ -53,7 +53,7 @@ function x0 = secondary_source_positions(conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 % NOTE: If you wanted to add a new type of loudspeaker array, do it in a way,

--- a/SFS_general/secondary_source_selection.m
+++ b/SFS_general/secondary_source_selection.m
@@ -53,7 +53,7 @@ function [x0,idx] = secondary_source_selection(x0,xs,src)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/secondary_source_tapering.m
+++ b/SFS_general/secondary_source_tapering.m
@@ -43,7 +43,7 @@ function x0 = secondary_source_tapering(x0,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/signal_from_spectrum.m
+++ b/SFS_general/signal_from_spectrum.m
@@ -45,7 +45,7 @@ function outsig = signal_from_spectrum(amplitude,phase,f,dim,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/spectrum_from_signal.m
+++ b/SFS_general/spectrum_from_signal.m
@@ -47,7 +47,7 @@ function varargout = spectrum_from_signal(signal,dim,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/sphbesselh.m
+++ b/SFS_general/sphbesselh.m
@@ -39,7 +39,7 @@ function out = sphbesselh(nu,k,z)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/sphbesselh_zeros.m
+++ b/SFS_general/sphbesselh_zeros.m
@@ -54,7 +54,7 @@ function [z,p] = sphbesselh_zeros(order)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/sphbesselj.m
+++ b/SFS_general/sphbesselj.m
@@ -38,7 +38,7 @@ function out = sphbesselj(nu,z)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/sphbessely.m
+++ b/SFS_general/sphbessely.m
@@ -38,7 +38,7 @@ function out = sphbessely(nu,z)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/sphharmonics.m
+++ b/SFS_general/sphharmonics.m
@@ -45,7 +45,7 @@ function [ Ynm ] = sphharmonics(n,m,theta,phi);
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/tapering_window.m
+++ b/SFS_general/tapering_window.m
@@ -61,7 +61,7 @@ function win = tapering_window(x0,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/thiran_filter.m
+++ b/SFS_general/thiran_filter.m
@@ -39,7 +39,7 @@ function [b,a] = thiran_filter(Norder,fdt)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/vector_norm.m
+++ b/SFS_general/vector_norm.m
@@ -41,7 +41,7 @@ function y = vector_norm(x,dim)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/vector_product.m
+++ b/SFS_general/vector_product.m
@@ -39,7 +39,7 @@ function y = vector_product(x1,x2,dim)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/virtual_secondary_source_positions.m
+++ b/SFS_general/virtual_secondary_source_positions.m
@@ -59,7 +59,7 @@ function xv = virtual_secondary_source_positions(x0,xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/warning_if_zero.m
+++ b/SFS_general/warning_if_zero.m
@@ -38,7 +38,7 @@ function warning_if_zero(P,t)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/weights_for_points_on_a_sphere_rectangle.m
+++ b/SFS_general/weights_for_points_on_a_sphere_rectangle.m
@@ -44,7 +44,7 @@ function [w] = weights_for_points_on_a_sphere_rectangle(phi,theta)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/xyz_axes_selection.m
+++ b/SFS_general/xyz_axes_selection.m
@@ -47,7 +47,7 @@ function [dimensions,x1,x2,x3] = xyz_axes_selection(x,y,z)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_general/xyz_grid.m
+++ b/SFS_general/xyz_grid.m
@@ -43,7 +43,7 @@ function [xx,yy,zz] = xyz_grid(X,Y,Z,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/get_position_and_orientation_ls.m
+++ b/SFS_helper/get_position_and_orientation_ls.m
@@ -45,7 +45,7 @@ function [xs,nxs] = get_position_and_orientation_ls(xs,conf);
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/get_sfs_path.m
+++ b/SFS_helper/get_sfs_path.m
@@ -30,7 +30,7 @@ function path = get_sfs_path()
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargchar.m
+++ b/SFS_helper/isargchar.m
@@ -34,7 +34,7 @@ function isargchar(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargcoord.m
+++ b/SFS_helper/isargcoord.m
@@ -38,7 +38,7 @@ function isargcoord(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargdir.m
+++ b/SFS_helper/isargdir.m
@@ -34,7 +34,7 @@ function isargdir(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargequallength.m
+++ b/SFS_helper/isargequallength.m
@@ -34,7 +34,7 @@ function isargequallength(x1,varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargequalsize.m
+++ b/SFS_helper/isargequalsize.m
@@ -34,7 +34,7 @@ function isargequalsize(x1,varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargfile.m
+++ b/SFS_helper/isargfile.m
@@ -34,7 +34,7 @@ function isargfile(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargmatrix.m
+++ b/SFS_helper/isargmatrix.m
@@ -34,7 +34,7 @@ function isargmatrix(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargnegativescalar.m
+++ b/SFS_helper/isargnegativescalar.m
@@ -34,7 +34,7 @@ function isargnegativescalar(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargnumeric.m
+++ b/SFS_helper/isargnumeric.m
@@ -34,7 +34,7 @@ function isargnumeric(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargposition.m
+++ b/SFS_helper/isargposition.m
@@ -34,7 +34,7 @@ function isargposition(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargpositivescalar.m
+++ b/SFS_helper/isargpositivescalar.m
@@ -34,7 +34,7 @@ function isargpositivescalar(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargscalar.m
+++ b/SFS_helper/isargscalar.m
@@ -34,7 +34,7 @@ function isargscalar(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargsecondarysource.m
+++ b/SFS_helper/isargsecondarysource.m
@@ -38,7 +38,7 @@ function isargsecondarysource(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargstruct.m
+++ b/SFS_helper/isargstruct.m
@@ -34,7 +34,7 @@ function isargstruct(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargvector.m
+++ b/SFS_helper/isargvector.m
@@ -34,7 +34,7 @@ function isargvector(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isargxs.m
+++ b/SFS_helper/isargxs.m
@@ -34,7 +34,7 @@ function isargxs(varargin)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/isoctave.m
+++ b/SFS_helper/isoctave.m
@@ -35,7 +35,7 @@ function bool = isoctave()
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/iswindows.m
+++ b/SFS_helper/iswindows.m
@@ -34,7 +34,7 @@ function bool = iswindows()
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/progress_bar.m
+++ b/SFS_helper/progress_bar.m
@@ -34,7 +34,7 @@ function progress_bar(ii,nii,message)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_helper/to_be_implemented.m
+++ b/SFS_helper/to_be_implemented.m
@@ -34,7 +34,7 @@ function to_be_implemented(mfile)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/dummy_irs.m
+++ b/SFS_ir/dummy_irs.m
@@ -43,7 +43,7 @@ function sofa = dummy_irs(nsamples,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/get_ir.m
+++ b/SFS_ir/get_ir.m
@@ -73,7 +73,7 @@ function ir = get_ir(sofa,X,head_orientation,xs,coordinate_system,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/interpolate_ir.m
+++ b/SFS_ir/interpolate_ir.m
@@ -68,7 +68,7 @@ function ir = interpolate_ir(ir,weights,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/ir_correct_distance.m
+++ b/SFS_ir/ir_correct_distance.m
@@ -48,7 +48,7 @@ function ir = ir_correct_distance(ir,ir_distance,r,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/reduce_ir.m
+++ b/SFS_ir/reduce_ir.m
@@ -43,7 +43,7 @@ function short_ir = reduce_ir(ir,fs,nsamples,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/shorten_ir.m
+++ b/SFS_ir/shorten_ir.m
@@ -41,7 +41,7 @@ function ir = shorten_ir(ir,nsamples)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/sofa2brs.m
+++ b/SFS_ir/sofa2brs.m
@@ -43,7 +43,7 @@ function brs = sofa2brs(sofa)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/sofa_get_data_fir.m
+++ b/SFS_ir/sofa_get_data_fir.m
@@ -50,7 +50,7 @@ function ir = sofa_get_data_fir(sofa,idx)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/sofa_get_data_fire.m
+++ b/SFS_ir/sofa_get_data_fire.m
@@ -55,7 +55,7 @@ function ir = sofa_get_data_fire(sofa,idxM,idxE)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/sofa_get_head_orientations.m
+++ b/SFS_ir/sofa_get_head_orientations.m
@@ -45,7 +45,7 @@ function [phi,theta,r] = sofa_get_head_orientations(sofa,idx)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/sofa_get_header.m
+++ b/SFS_ir/sofa_get_header.m
@@ -41,7 +41,7 @@ function header = sofa_get_header(sofa)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/sofa_get_listener_position.m
+++ b/SFS_ir/sofa_get_listener_position.m
@@ -45,7 +45,7 @@ function X = sofa_get_listener_position(sofa,coordinate_system)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/sofa_get_secondary_sources.m
+++ b/SFS_ir/sofa_get_secondary_sources.m
@@ -51,7 +51,7 @@ function [x0,nss] = sofa_get_secondary_sources(sofa,idx,coordinate_system)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ir/sofa_is_file.m
+++ b/SFS_ir/sofa_is_file.m
@@ -42,7 +42,7 @@ function boolean = sofa_is_file(sofa)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/circexp_mono/circexp_mono_ps.m
+++ b/SFS_monochromatic/circexp_mono/circexp_mono_ps.m
@@ -43,7 +43,7 @@ function Pm = circexp_mono_ps(xs,Nce,f,xq,fhp,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/circexp_mono/circexp_mono_pw.m
+++ b/SFS_monochromatic/circexp_mono/circexp_mono_pw.m
@@ -42,7 +42,7 @@ function Pm = circexp_mono_pw(npw,Nce,f,xq,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_function_mono_localwfs_sbl.m
+++ b/SFS_monochromatic/driving_function_mono_localwfs_sbl.m
@@ -45,7 +45,7 @@ function D = driving_function_mono_localwfs_sbl(x0,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_function_mono_localwfs_vss.m
+++ b/SFS_monochromatic/driving_function_mono_localwfs_vss.m
@@ -60,7 +60,7 @@ function [D,x0,xv,idx] = driving_function_mono_localwfs_vss(x0,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 %% ===== Checking of input  parameters ==================================

--- a/SFS_monochromatic/driving_function_mono_nfchoa.m
+++ b/SFS_monochromatic/driving_function_mono_nfchoa.m
@@ -49,7 +49,7 @@ function D = driving_function_mono_nfchoa(x0,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_function_mono_sdm.m
+++ b/SFS_monochromatic/driving_function_mono_sdm.m
@@ -46,7 +46,7 @@ function D = driving_function_mono_sdm(x0,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_function_mono_sdm_kx.m
+++ b/SFS_monochromatic/driving_function_mono_sdm_kx.m
@@ -46,7 +46,7 @@ function D = driving_function_mono_sdm_kx(kx,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_function_mono_wfs.m
+++ b/SFS_monochromatic/driving_function_mono_wfs.m
@@ -48,7 +48,7 @@ function D = driving_function_mono_wfs(x0,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_localwfs_sbl_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_localwfs_sbl_ps.m
@@ -47,7 +47,7 @@ function D = driving_function_mono_localwfs_sbl_ps(x0,xs,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_localwfs_sbl_pw.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_localwfs_sbl_pw.m
@@ -47,7 +47,7 @@ function D = driving_function_mono_localwfs_sbl_pw(x0,nk,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_fs.m
@@ -41,7 +41,7 @@ function D = driving_function_mono_nfchoa_fs(x0,xs,f,N,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_ls.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_ls.m
@@ -42,7 +42,7 @@ function D = driving_function_mono_nfchoa_ls(x0,xs,f,N,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_ps.m
@@ -41,7 +41,7 @@ function D = driving_function_mono_nfchoa_ps(x0,xs,f,N,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_pw.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_nfchoa_pw.m
@@ -41,7 +41,7 @@ function D = driving_function_mono_nfchoa_pw(x0,nk,f,N,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_fs.m
@@ -40,7 +40,7 @@ function D = driving_function_mono_sdm_fs(x0,nk,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_fs.m
@@ -47,7 +47,7 @@ function D = driving_function_mono_sdm_kx_fs(kx,xs,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_ls.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_ls.m
@@ -41,7 +41,7 @@ function D = driving_function_mono_sdm_kx_ls(kx,xs,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_ps.m
@@ -41,7 +41,7 @@ function D = driving_function_mono_sdm_kx_ps(kx,xs,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_pw.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_kx_pw.m
@@ -41,7 +41,7 @@ function D = driving_function_mono_sdm_kx_pw(kx,nk,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_ls.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_ls.m
@@ -40,7 +40,7 @@ function D = driving_function_mono_sdm_ls(x0,nk,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_ps.m
@@ -40,7 +40,7 @@ function D = driving_function_mono_sdm_ps(x0,nk,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_pw.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_sdm_pw.m
@@ -40,7 +40,7 @@ function D = driving_function_mono_sdm_pw(x0,nk,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_fs.m
@@ -59,7 +59,7 @@ function D = driving_function_mono_wfs_fs(x0,nx0,xs,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_ls.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_ls.m
@@ -46,7 +46,7 @@ function D = driving_function_mono_wfs_ls(x0,nx0,xs,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_ps.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_ps.m
@@ -54,7 +54,7 @@ function D = driving_function_mono_wfs_ps(x0,nx0,xs,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_pw.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_pw.m
@@ -46,7 +46,7 @@ function D = driving_function_mono_wfs_pw(x0,nx0,nk,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_pwd.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_pwd.m
@@ -41,7 +41,7 @@ function D = driving_function_mono_wfs_pwd(x0,Ppwd,f,xq,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_vss.m
+++ b/SFS_monochromatic/driving_functions_mono/driving_function_mono_wfs_vss.m
@@ -55,7 +55,7 @@ function D = driving_function_mono_wfs_vss(x0,xv,srcv,Dv,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 %% ===== Checking of input  parameters ==================================

--- a/SFS_monochromatic/greens_function_mono.m
+++ b/SFS_monochromatic/greens_function_mono.m
@@ -50,7 +50,7 @@ function G = greens_function_mono(x,y,z,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/movie_sound_field_mono_wfs.m
+++ b/SFS_monochromatic/movie_sound_field_mono_wfs.m
@@ -49,7 +49,7 @@ function movie_sound_field_mono_wfs(X,Y,Z,xs,src,f,outfile,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/pwd_mono/pwd_mono_circexp.m
+++ b/SFS_monochromatic/pwd_mono/pwd_mono_circexp.m
@@ -40,7 +40,7 @@ function Ppwd = pwd_mono_circexp(Pm,Npw)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/sound_field_mono.m
+++ b/SFS_monochromatic/sound_field_mono.m
@@ -76,7 +76,7 @@ function varargout = sound_field_mono(X,Y,Z,x0,src,D,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/sound_field_mono_line_source.m
+++ b/SFS_monochromatic/sound_field_mono_line_source.m
@@ -53,7 +53,7 @@ function varargout = sound_field_mono_line_source(X,Y,Z,xs,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/sound_field_mono_localwfs_sbl.m
+++ b/SFS_monochromatic/sound_field_mono_localwfs_sbl.m
@@ -63,7 +63,7 @@ function varargout = sound_field_mono_localwfs_sbl(X,Y,Z,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/sound_field_mono_localwfs_vss.m
+++ b/SFS_monochromatic/sound_field_mono_localwfs_vss.m
@@ -61,7 +61,7 @@ function varargout = sound_field_mono_localwfs_vss(X,Y,Z,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/sound_field_mono_nfchoa.m
+++ b/SFS_monochromatic/sound_field_mono_nfchoa.m
@@ -59,7 +59,7 @@ function varargout = sound_field_mono_nfchoa(X,Y,Z,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/sound_field_mono_plane_wave.m
+++ b/SFS_monochromatic/sound_field_mono_plane_wave.m
@@ -53,7 +53,7 @@ function varargout = sound_field_mono_plane_wave(X,Y,Z,xs,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/sound_field_mono_point_source.m
+++ b/SFS_monochromatic/sound_field_mono_point_source.m
@@ -53,7 +53,7 @@ function varargout = sound_field_mono_point_source(X,Y,Z,xs,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/sound_field_mono_sdm.m
+++ b/SFS_monochromatic/sound_field_mono_sdm.m
@@ -60,7 +60,7 @@ function varargout = sound_field_mono_sdm(X,Y,Z,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/sound_field_mono_sdm_kx.m
+++ b/SFS_monochromatic/sound_field_mono_sdm_kx.m
@@ -76,7 +76,7 @@ function varargout = sound_field_mono_sdm_kx(X,Y,Z,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_monochromatic/sound_field_mono_wfs.m
+++ b/SFS_monochromatic/sound_field_mono_wfs.m
@@ -60,7 +60,7 @@ function varargout = sound_field_mono_wfs(X,Y,Z,xs,src,f,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_octave/db.m
+++ b/SFS_octave/db.m
@@ -39,7 +39,7 @@ function sig = db(sig)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_octave/rms.m
+++ b/SFS_octave/rms.m
@@ -38,7 +38,7 @@ function level = rms(sig,dim)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/colormaps/inferno.m
+++ b/SFS_plotting/colormaps/inferno.m
@@ -43,7 +43,7 @@ function m = inferno(n)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/colormaps/magma.m
+++ b/SFS_plotting/colormaps/magma.m
@@ -43,7 +43,7 @@ function m = magma(n)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/colormaps/moreland.m
+++ b/SFS_plotting/colormaps/moreland.m
@@ -46,7 +46,7 @@ function m = moreland(n)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/colormaps/yellowred.m
+++ b/SFS_plotting/colormaps/yellowred.m
@@ -43,7 +43,7 @@ function map = yellowred(n)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/draw_loudspeakers.m
+++ b/SFS_plotting/draw_loudspeakers.m
@@ -44,7 +44,7 @@ function draw_loudspeakers(x0,dimensions,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/figsize.m
+++ b/SFS_plotting/figsize.m
@@ -38,7 +38,7 @@ function figsize(x,y,unit)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/generate_colormap.m
+++ b/SFS_plotting/generate_colormap.m
@@ -43,7 +43,7 @@ function m = generate_colormap(table,n)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/generate_movie.m
+++ b/SFS_plotting/generate_movie.m
@@ -41,7 +41,7 @@ function generate_movie(outfile,directory,pattern)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/gp_draw_loudspeakers.gnu
+++ b/SFS_plotting/gp_draw_loudspeakers.gnu
@@ -41,7 +41,7 @@
 # The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 # methods like wave field synthesis or higher order ambisonics.              *
 #                                                                            *
-# https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+# https://sfs.readthedocs.io                                                 *
 #*****************************************************************************
 
 

--- a/SFS_plotting/gp_load.m
+++ b/SFS_plotting/gp_load.m
@@ -40,7 +40,7 @@ function [x,y,header] = gp_load(file)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 % FIXME: is this function doing what it should do?

--- a/SFS_plotting/gp_save.m
+++ b/SFS_plotting/gp_save.m
@@ -36,7 +36,7 @@ function gp_save(file,data,header)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/gp_save_loudspeakers.m
+++ b/SFS_plotting/gp_save_loudspeakers.m
@@ -39,7 +39,7 @@ function gp_save_loudspeakers(file,x0)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/gp_save_matrix.m
+++ b/SFS_plotting/gp_save_matrix.m
@@ -43,7 +43,7 @@ function gp_save_matrix(file,x,y,M)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/gp_set_head.gnu
+++ b/SFS_plotting/gp_set_head.gnu
@@ -39,7 +39,7 @@
 # The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 # methods like wave field synthesis or higher order ambisonics.              *
 #                                                                            *
-# https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+# https://sfs.readthedocs.io                                                 *
 #*****************************************************************************
 
 

--- a/SFS_plotting/gp_set_loudspeaker.gnu
+++ b/SFS_plotting/gp_set_loudspeaker.gnu
@@ -42,7 +42,7 @@
 # The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 # methods like wave field synthesis or higher order ambisonics.              *
 #                                                                            *
-# https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+# https://sfs.readthedocs.io                                                 *
 #*****************************************************************************
 
 

--- a/SFS_plotting/norm_sound_field.m
+++ b/SFS_plotting/norm_sound_field.m
@@ -45,7 +45,7 @@ function P = norm_sound_field(P,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/plot_sound_field.m
+++ b/SFS_plotting/plot_sound_field.m
@@ -47,7 +47,7 @@ function plot_sound_field(P,X,Y,Z,x0,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/print_eps.m
+++ b/SFS_plotting/print_eps.m
@@ -34,7 +34,7 @@ function print_eps(outfile)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/print_png.m
+++ b/SFS_plotting/print_png.m
@@ -34,7 +34,7 @@ function print_png(outfile)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/set_colorbar.m
+++ b/SFS_plotting/set_colorbar.m
@@ -37,7 +37,7 @@ function set_colorbar(conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/set_colormap.m
+++ b/SFS_plotting/set_colormap.m
@@ -41,7 +41,7 @@ function set_colormap(map)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/set_font_size.m
+++ b/SFS_plotting/set_font_size.m
@@ -34,7 +34,7 @@ function set_font_size(fontsize)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/set_font_type.m
+++ b/SFS_plotting/set_font_type.m
@@ -34,7 +34,7 @@ function set_font_type(font)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_plotting/turn_imagesc.m
+++ b/SFS_plotting/turn_imagesc.m
@@ -27,7 +27,7 @@ function turn_imagesc()
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ssr/ssr_brs.m
+++ b/SFS_ssr/ssr_brs.m
@@ -48,7 +48,7 @@ function brs = ssr_brs(X,phi,x0,d,irs,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ssr/ssr_brs_nfchoa.m
+++ b/SFS_ssr/ssr_brs_nfchoa.m
@@ -53,7 +53,7 @@ function [brs,delay] = ssr_brs_nfchoa(X,phi,xs,src,irs,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ssr/ssr_brs_point_source.m
+++ b/SFS_ssr/ssr_brs_point_source.m
@@ -48,7 +48,7 @@ function brs = ssr_brs_point_source(X,phi,xs,irs,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ssr/ssr_brs_wfs.m
+++ b/SFS_ssr/ssr_brs_wfs.m
@@ -51,7 +51,7 @@ function [brs,delay] = ssr_brs_wfs(X,phi,xs,src,irs,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ssr/ssr_generic_nfchoa.m
+++ b/SFS_ssr/ssr_generic_nfchoa.m
@@ -50,7 +50,7 @@ function ir = ssr_generic_nfchoa(xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_ssr/ssr_generic_wfs.m
+++ b/SFS_ssr/ssr_generic_wfs.m
@@ -50,7 +50,7 @@ function ir = ssr_generic_wfs(xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_start.m
+++ b/SFS_start.m
@@ -38,7 +38,7 @@ function SFS_start(printbanner)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_stop.m
+++ b/SFS_stop.m
@@ -34,7 +34,7 @@ function SFS_stop()
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/circexp_imp/circexp_imp_ps.m
+++ b/SFS_time_domain/circexp_imp/circexp_imp_ps.m
@@ -43,7 +43,7 @@ function [pm,delay_offset] = circexp_imp_ps(xs,Nce,xq,fhp,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/circexp_imp/circexp_imp_pw.m
+++ b/SFS_time_domain/circexp_imp/circexp_imp_pw.m
@@ -42,7 +42,7 @@ function [pm,delay_offset] = circexp_imp_pw(npw,Nce,xq,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/dirac_imp.m
+++ b/SFS_time_domain/dirac_imp.m
@@ -34,7 +34,7 @@ function pulse = dirac_imp()
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_function_imp_localwfs_sbl.m
+++ b/SFS_time_domain/driving_function_imp_localwfs_sbl.m
@@ -46,7 +46,7 @@ function [d,delay_offset] = driving_function_imp_localwfs_sbl(x0,xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_function_imp_localwfs_vss.m
+++ b/SFS_time_domain/driving_function_imp_localwfs_vss.m
@@ -61,7 +61,7 @@ function [d,x0,xv,idx,delay_offset] = driving_function_imp_localwfs_vss(x0,xs,sr
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_function_imp_nfchoa.m
+++ b/SFS_time_domain/driving_function_imp_nfchoa.m
@@ -62,7 +62,7 @@ function [d,dm,delay_offset] = driving_function_imp_nfchoa(x0,xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_function_imp_wfs.m
+++ b/SFS_time_domain/driving_function_imp_wfs.m
@@ -55,7 +55,7 @@ function [d,delay,weight,delay_offset] = driving_function_imp_wfs(x0,xs,src,conf
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_localwfs_sbl_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_localwfs_sbl_ps.m
@@ -47,7 +47,7 @@ function [d,delay_offset] = driving_function_imp_localwfs_sbl_ps(x0,xs,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_localwfs_sbl_pw.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_localwfs_sbl_pw.m
@@ -47,7 +47,7 @@ function [d,delay_offset] = driving_function_imp_localwfs_sbl_pw(x0,nk,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_fs.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_fs.m
@@ -43,7 +43,7 @@ function [sos,g] = driving_function_imp_nfchoa_fs(N,R,r,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ls.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ls.m
@@ -43,7 +43,7 @@ function [sos,g] = driving_function_imp_nfchoa_ls(N,R,r,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_ps.m
@@ -50,7 +50,7 @@ function [sos,g] = driving_function_imp_nfchoa_ps(N,R,r,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_pw.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_nfchoa_pw.m
@@ -49,7 +49,7 @@ function [sos,g] = driving_function_imp_nfchoa_pw(N,R,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_fs.m
@@ -53,7 +53,7 @@ function [delay,weight] = driving_function_imp_wfs_fs(x0,nx0,xs,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ls.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ls.m
@@ -49,7 +49,7 @@ function [delay,weight] = driving_function_imp_wfs_ls(x0,nx0,xs,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ps.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_ps.m
@@ -49,7 +49,7 @@ function [delay,weight] = driving_function_imp_wfs_ps(x0,nx0,xs,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_pw.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_pw.m
@@ -46,7 +46,7 @@ function [delay,weight] = driving_function_imp_wfs_pw(x0,nx0,nk,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_pwd.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_pwd.m
@@ -41,7 +41,7 @@ function [d,delay_offset] = driving_function_imp_wfs_pwd(x0,ppwd,xq,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_vss.m
+++ b/SFS_time_domain/driving_functions_imp/driving_function_imp_wfs_vss.m
@@ -55,7 +55,7 @@ function [d,delay_offset] = driving_function_imp_wfs_vss(x0,xv,srcv,dv,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 %% ===== Checking of input  parameters ==================================

--- a/SFS_time_domain/greens_function_imp.m
+++ b/SFS_time_domain/greens_function_imp.m
@@ -55,7 +55,7 @@ function [g,t] = greens_function_imp(x,y,z,xs,src,t,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/localwfs_findhpref.m
+++ b/SFS_time_domain/localwfs_findhpref.m
@@ -43,7 +43,7 @@ function [hpreflow,hprefhigh] = localwfs_findhpref(X,phi,xs,src,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/movie_sound_field_imp_wfs.m
+++ b/SFS_time_domain/movie_sound_field_imp_wfs.m
@@ -48,7 +48,7 @@ function movie_sound_field_imp_wfs(X,Y,Z,xs,src,outfile,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/pwd_imp/pwd_imp_circexp.m
+++ b/SFS_time_domain/pwd_imp/pwd_imp_circexp.m
@@ -41,7 +41,7 @@ function ppwd = pwd_imp_circexp(pm,Npw)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/sound_field_imp.m
+++ b/SFS_time_domain/sound_field_imp.m
@@ -64,7 +64,7 @@ function varargout = sound_field_imp(X,Y,Z,x0,src,d,t,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/sound_field_imp_line_source.m
+++ b/SFS_time_domain/sound_field_imp_line_source.m
@@ -56,7 +56,7 @@ function varargout = sound_field_imp_line_source(X,Y,Z,xs,t,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/sound_field_imp_localwfs_sbl.m
+++ b/SFS_time_domain/sound_field_imp_localwfs_sbl.m
@@ -63,7 +63,7 @@ function varargout = sound_field_imp_localwfs_sbl(X,Y,Z,xs,src,t,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/sound_field_imp_localwfs_vss.m
+++ b/SFS_time_domain/sound_field_imp_localwfs_vss.m
@@ -63,7 +63,7 @@ function varargout = sound_field_imp_localwfs_vss(X,Y,Z,xs,src,t,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/sound_field_imp_nfchoa.m
+++ b/SFS_time_domain/sound_field_imp_nfchoa.m
@@ -62,7 +62,7 @@ function varargout = sound_field_imp_nfchoa(X,Y,Z,xs,src,t,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/sound_field_imp_plane_wave.m
+++ b/SFS_time_domain/sound_field_imp_plane_wave.m
@@ -56,7 +56,7 @@ function varargout = sound_field_imp_plane_wave(X,Y,Z,xs,t,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/sound_field_imp_point_source.m
+++ b/SFS_time_domain/sound_field_imp_point_source.m
@@ -56,7 +56,7 @@ function varargout = sound_field_imp_point_source(X,Y,Z,xs,t,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/sound_field_imp_wfs.m
+++ b/SFS_time_domain/sound_field_imp_wfs.m
@@ -62,7 +62,7 @@ function varargout = sound_field_imp_wfs(X,Y,Z,xs,src,t,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/wfs_fir_prefilter.m
+++ b/SFS_time_domain/wfs_fir_prefilter.m
@@ -41,7 +41,7 @@ function hpre = wfs_fir_prefilter(conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_time_domain/wfs_iir_prefilter.m
+++ b/SFS_time_domain/wfs_iir_prefilter.m
@@ -73,7 +73,7 @@ function hpre = wfs_iir_prefilter(conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 % Revision: 07/02/2013 frank.schultz@uni-rostock.de initial development      *
 %*****************************************************************************
 

--- a/SFS_time_domain/wfs_preequalization.m
+++ b/SFS_time_domain/wfs_preequalization.m
@@ -39,7 +39,7 @@ function [ir,delay] = wfs_preequalization(ir,conf)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/SFS_version.m
+++ b/SFS_version.m
@@ -34,7 +34,7 @@ function versionnumber = SFS_version()
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_all.m
+++ b/validation/test_all.m
@@ -39,7 +39,7 @@ function status = test_all(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_binaural_synthesis.m
+++ b/validation/test_binaural_synthesis.m
@@ -39,7 +39,7 @@ function status = test_binaural_synthesis(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_colormaps.m
+++ b/validation/test_colormaps.m
@@ -36,7 +36,7 @@ function status = test_colormaps(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_delayline.m
+++ b/validation/test_delayline.m
@@ -40,7 +40,7 @@ function status = test_delayline(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_driving_functions.m
+++ b/validation/test_driving_functions.m
@@ -36,7 +36,7 @@ function status = test_driving_functions(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_driving_functions_imp_with_delay.m
+++ b/validation/test_driving_functions_imp_with_delay.m
@@ -37,7 +37,7 @@ function status = test_driving_functions_imp_with_delay(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_exp_imp.m
+++ b/validation/test_exp_imp.m
@@ -42,7 +42,7 @@ function status = test_exp_imp(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_exp_mono.m
+++ b/validation/test_exp_mono.m
@@ -42,7 +42,7 @@ function status = test_exp_mono(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_hrtf_extrapolation.m
+++ b/validation/test_hrtf_extrapolation.m
@@ -39,7 +39,7 @@ function status = test_hrtf_extrapolation(modus,hrtf_set)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_imp_25d.m
+++ b/validation/test_imp_25d.m
@@ -36,7 +36,7 @@ function status = test_imp_25d(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_interpolation_methods.m
+++ b/validation/test_interpolation_methods.m
@@ -37,7 +37,7 @@ function status = test_interpolation_methods(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_interpolation_point_selection.m
+++ b/validation/test_interpolation_point_selection.m
@@ -37,7 +37,7 @@ function status = test_interpolation_point_selection(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_linkwitz_riley.m
+++ b/validation/test_linkwitz_riley.m
@@ -36,7 +36,7 @@ function status = test_linkwitz_riley(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 status = false;

--- a/validation/test_localwfs_sbl.m
+++ b/validation/test_localwfs_sbl.m
@@ -36,7 +36,7 @@ function status = test_localwfs_sbl(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_localwfs_vss.m
+++ b/validation/test_localwfs_vss.m
@@ -36,7 +36,7 @@ function status = test_localwfs_vss(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_modal_weighting.m
+++ b/validation/test_modal_weighting.m
@@ -39,7 +39,7 @@ function status = test_modal_weighting(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_non_regular_grid.m
+++ b/validation/test_non_regular_grid.m
@@ -40,7 +40,7 @@ function status = test_non_regular_grid(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_plotting.m
+++ b/validation/test_plotting.m
@@ -36,7 +36,7 @@ function status = test_plotting(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_secondary_source_diameter.m
+++ b/validation/test_secondary_source_diameter.m
@@ -38,7 +38,7 @@ function status = test_secondary_source_diameter(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_secondary_source_positions.m
+++ b/validation/test_secondary_source_positions.m
@@ -38,7 +38,7 @@ function status = test_secondary_source_positions(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_secondary_source_selection.m
+++ b/validation/test_secondary_source_selection.m
@@ -38,7 +38,7 @@ function status = test_secondary_source_selection(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_spectrum_signal_conversion.m
+++ b/validation/test_spectrum_signal_conversion.m
@@ -37,7 +37,7 @@ function status = test_spectrum_signal_conversion(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_sphbesselh_zeros.m
+++ b/validation/test_sphbesselh_zeros.m
@@ -37,7 +37,7 @@ function status = test_sphbesselh_zeros(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 status = false;

--- a/validation/test_tapering_window.m
+++ b/validation/test_tapering_window.m
@@ -38,7 +38,7 @@ function status = test_tapering_window(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_wfs_25d.m
+++ b/validation/test_wfs_25d.m
@@ -36,7 +36,7 @@ function status = test_wfs_25d(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 

--- a/validation/test_wfs_iir_prefilter.m
+++ b/validation/test_wfs_iir_prefilter.m
@@ -40,7 +40,7 @@ function status = test_wfs_iir_prefilter(modus)
 % The SFS Toolbox  allows to simulate and  investigate sound field synthesis *
 % methods like wave field synthesis or higher order ambisonics.              *
 %                                                                            *
-% https://sfs.readthedocs.io                            sfstoolbox@gmail.com *
+% https://sfs.readthedocs.io                                                 *
 %*****************************************************************************
 
 


### PR DESCRIPTION
As during the last years nobody contacted us via email and only I have access (at least my guess) to it, I would propose to remove it and disable it in two years together with the sfstoolbox.org domain.